### PR TITLE
Handle stray sign characters in parseNum and fix this-month filter range

### DIFF
--- a/index.html
+++ b/index.html
@@ -677,8 +677,16 @@
             let str = String(value).trim();
             
             // Remover espacios, €, y otros caracteres no numéricos excepto comas, puntos y signos
-            str = str.replace(/[^\d,.\-+]/g, '');
-            
+            str = str.replace(/[^\d,\.\-+]/g, '');
+
+            // Permitir solo un signo al inicio del número
+            if (str[0] === '-' || str[0] === '+') {
+                const sign = str[0];
+                str = sign + str.slice(1).replace(/[+-]/g, '');
+            } else {
+                str = str.replace(/[+-]/g, '');
+            }
+
             // Si está vacío después de limpiar, retornar 0
             if (!str) return 0;
             
@@ -1089,8 +1097,13 @@
             // Último día del mes
             const lastDay = new Date(year, month + 1, 0);
             
-            const firstDayStr = firstDay.toISOString().split('T')[0];
-            const lastDayStr = lastDay.toISOString().split('T')[0];
+            // Ajustar las fechas para evitar desfases por zona horaria
+            const firstDayStr = new Date(firstDay.getTime() - firstDay.getTimezoneOffset() * 60000)
+                .toISOString()
+                .split('T')[0];
+            const lastDayStr = new Date(lastDay.getTime() - lastDay.getTimezoneOffset() * 60000)
+                .toISOString()
+                .split('T')[0];
             
             document.getElementById('fechaDesde').value = firstDayStr;
             document.getElementById('fechaHasta').value = lastDayStr;


### PR DESCRIPTION
## Summary
- Sanitize numeric input parsing by keeping only a single leading sign in `parseNum`
- Fix "Este mes" date filter by adjusting for timezone offsets

## Testing
- `npm test` *(fails: Could not read package.json)*
- `TZ='Europe/Madrid' node - <<'NODE'...`

------
https://chatgpt.com/codex/tasks/task_e_68a127ef13d88329b0cebfba8d42e8fa