### PR TITLE
Refactor app into modular modules

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,41 @@
+export function saveToLocalStorage(key, data) {
+    localStorage.setItem(key, JSON.stringify(data));
+}
+
+export function getFromLocalStorage(key) {
+    const data = localStorage.getItem(key);
+    return data ? JSON.parse(data) : null;
+}
+
+export function getDayIndex() {
+    return getFromLocalStorage('caja:index') || [];
+}
+
+export function updateDayIndex(date, action = 'add') {
+    let index = getDayIndex();
+
+    if (action === 'add') {
+        if (!index.includes(date)) {
+            index.push(date);
+            index.sort();
+        }
+    } else if (action === 'remove') {
+        index = index.filter(d => d !== date);
+    }
+
+    saveToLocalStorage('caja:index', index);
+}
+
+export function loadDay(date) {
+    return getFromLocalStorage(`caja:${date}`);
+}
+
+export function saveDayData(date, data) {
+    saveToLocalStorage(`caja:${date}`, data);
+    updateDayIndex(date, 'add');
+}
+
+export function deleteDay(date) {
+    localStorage.removeItem(`caja:${date}`);
+    updateDayIndex(date, 'remove');
+}

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,104 @@
+import { formatCurrency, formatDate, computeTotals } from './utils.js';
+import { getDayIndex, loadDay } from './storage.js';
+
+export function renderMovimientos(movimientos) {
+    const container = document.getElementById('movimientosList');
+
+    if (!movimientos.length) {
+        container.innerHTML = '<p style="text-align: center; color: #6c757d; padding: 20px;">No hay movimientos registrados</p>';
+        return;
+    }
+
+    container.innerHTML = movimientos.map((mov, index) => `
+        <div class="movimiento-item">
+            <strong>${mov.tipo === 'entrada' ? 'Entrada' : 'Salida'}</strong>
+            <span>${mov.quien || 'No especificado'}</span>
+            <span class="text-right">${formatCurrency(mov.importe)} €</span>
+            <button type="button" class="btn btn-danger btn-small" onclick="removeMovimiento(${index})">🗑️</button>
+        </div>
+    `).join('');
+}
+
+export function renderHistorial(filteredDates) {
+    const tbody = document.getElementById('historialTable');
+    let dates = getDayIndex();
+
+    if (filteredDates) {
+        dates = dates.filter(date => date >= filteredDates.desde && date <= filteredDates.hasta);
+    }
+
+    if (!dates.length) {
+        tbody.innerHTML = '<tr><td colspan="10" class="text-center">No hay datos para mostrar</td></tr>';
+        return;
+    }
+
+    dates.sort((a, b) => b.localeCompare(a));
+
+    tbody.innerHTML = dates.map(date => {
+        const data = loadDay(date);
+        if (!data) return '';
+
+        const totals = computeTotals(data.apertura, data.ingresos, data.movimientos, data.cierre);
+
+        return `
+            <tr>
+                <td>${formatDate(date)}</td>
+                <td>${data.sucursal}</td>
+                <td class="text-right">${formatCurrency(data.apertura)} €</td>
+                <td class="text-right">${formatCurrency(data.ingresos)} €</td>
+                <td class="text-right">${formatCurrency(totals.entradas)} €</td>
+                <td class="text-right">${formatCurrency(totals.salidas)} €</td>
+                <td class="text-right">${formatCurrency(totals.total)} €</td>
+                <td class="text-right">${formatCurrency(data.cierre)} €</td>
+                <td class="text-right" style="color: ${Math.abs(totals.diff) < 0.01 ? '#28a745' : '#dc3545'}">${formatCurrency(totals.diff)} €</td>
+                <td class="text-center">
+                    <button class="btn btn-primary btn-small" onclick="editDay('${date}')">✏️</button>
+                    <button class="btn btn-danger btn-small" onclick="deleteDayFromHistorial('${date}')">🗑️</button>
+                </td>
+            </tr>
+        `;
+    }).join('');
+}
+
+export function showAlert(message, type = 'info') {
+    const existingAlerts = document.querySelectorAll('.alert');
+    existingAlerts.forEach(alert => alert.remove());
+
+    const alert = document.createElement('div');
+    alert.className = `alert alert-${type}`;
+    alert.textContent = message;
+
+    const header = document.querySelector('.header');
+    header.parentNode.insertBefore(alert, header.nextSibling);
+
+    setTimeout(() => {
+        if (alert.parentNode) {
+            alert.remove();
+        }
+    }, 5000);
+}
+
+export function displayTestResults(results) {
+    const panel = document.getElementById('testsPanel');
+    const resultsDiv = document.getElementById('testResults');
+
+    const allPassed = results.every(r => r.passed);
+
+    if (allPassed) {
+        console.log('🎉 Todos los tests pasaron correctamente');
+        showAlert('Todos los tests pasaron correctamente', 'success');
+    } else {
+        resultsDiv.innerHTML = results.map(result => {
+            const className = result.passed ? 'test-pass' : 'test-fail';
+            const icon = result.passed ? '✅' : '❌';
+            const errorText = result.error ? ` - ${result.error}` : '';
+            return `<div class="${className}">${icon} ${result.name}${errorText}</div>`;
+        }).join('');
+
+        panel.classList.add('show');
+    }
+}
+
+export function hideTests() {
+    document.getElementById('testsPanel').classList.remove('show');
+}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,75 @@
+export function parseNum(value) {
+    if (typeof value === 'number') return value;
+    if (!value || value === '') return 0;
+
+    let str = String(value).trim();
+    str = str.replace(/[^\d,\.\-+]/g, '');
+
+    if (str[0] === '-' || str[0] === '+') {
+        const sign = str[0];
+        str = sign + str.slice(1).replace(/[+-]/g, '');
+    } else {
+        str = str.replace(/[+-]/g, '');
+    }
+
+    if (!str) return 0;
+
+    if (str.includes(',') && str.includes('.')) {
+        str = str.replace(/\./g, '').replace(',', '.');
+    } else if (str.includes(',')) {
+        str = str.replace(',', '.');
+    }
+
+    const num = parseFloat(str);
+    return isNaN(num) ? 0 : num;
+}
+
+export function formatCurrency(value) {
+    const num = parseNum(value);
+    return num.toLocaleString('es-ES', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+}
+
+export function formatDate(dateStr) {
+    const date = new Date(dateStr + 'T00:00:00');
+    return date.toLocaleDateString('es-ES');
+}
+
+export function getTodayString() {
+    const today = new Date();
+    return today.toISOString().split('T')[0];
+}
+
+export function computeTotals(apertura, ingresos, movimientos, cierre) {
+    const aperturaNum = parseNum(apertura);
+    const ingresosNum = parseNum(ingresos);
+    const cierreNum = parseNum(cierre);
+
+    let entradas = 0;
+    let salidas = 0;
+
+    if (Array.isArray(movimientos)) {
+        movimientos.forEach(mov => {
+            if (mov && typeof mov === 'object') {
+                const importe = parseNum(mov.importe);
+                if (mov.tipo === 'entrada') {
+                    entradas += importe;
+                } else if (mov.tipo === 'salida') {
+                    salidas += importe;
+                }
+            }
+        });
+    }
+
+    const total = aperturaNum + ingresosNum + entradas - salidas;
+    const diff = total - cierreNum;
+
+    return {
+        entradas,
+        salidas,
+        total,
+        diff
+    };
+}


### PR DESCRIPTION
## Summary
- move number parsing and currency formatting helpers into `utils.js`
- centralize localStorage helpers in `storage.js`
- extract UI rendering and alerts into `ui.js` and update `app.js`

## Testing
- `node -e "global.window={}; global.document={addEventListener:()=>{}}; import('./app.js').then(()=>console.log('loaded')).catch(err=>console.error(err));"`


------
https://chatgpt.com/codex/tasks/task_e_68a13438eea88329afbe3c70d76514f3