### PR TITLE
feat: add service worker for offline support

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,9 @@
 import { parseNum, formatCurrency, formatDate, getTodayString, computeTotals } from "./utils.js";
 import { getDayIndex, loadDay, saveDayData, deleteDay } from "./storage.js";
 import { renderMovimientos, renderHistorial, showAlert, displayTestResults, hideTests } from "./ui.js";
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('./service-worker.js');
+}
 
 // Variables globales
 let currentMovimientos = [];

--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,6 @@
       "sizes": "180x180",
       "type": "image/png"
     }
-  ]
+  ],
+  "scope": "./"
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'pwa-cache-v1';
+const PRECACHE_URLS = [
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.json',
+  './icon-180.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add service worker with precache of core assets
- register service worker in app.js
- add scope to web app manifest

## Testing
- `node --check service-worker.js`
- `node --check app.js`
- `python -m json.tool manifest.json`
- `python -m http.server 8080 &` then `curl -I http://localhost:8080/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a136257b648329956762f578a0f561