### PR TITLE
Improve filtering logic and localStorage error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -133,10 +133,15 @@ function saveDay() {
         cierre,
         responsableCierre
     };
-    
-    saveDayData(fecha, dayData);
-    showAlert('Día guardado correctamente', 'success');
-    renderHistorial(filteredDates);
+
+    try {
+        saveDayData(fecha, dayData);
+        showAlert('Día guardado correctamente', 'success');
+        renderHistorial(filteredDates);
+    } catch (error) {
+        console.error('Error al guardar en localStorage', error);
+        showAlert('No se pudo guardar el día. Revisa la consola para más detalles', 'danger');
+    }
 }
 
 function newDay() {
@@ -194,29 +199,36 @@ function editDay(fecha) {
 
 // Funciones de filtrado
 function filterToday() {
-    const today = getTodayString();
-    document.getElementById('fechaDesde').value = today;
-    document.getElementById('fechaHasta').value = today;
+    const today = new Date();
+    const todayStr = new Date(today.getTime() - today.getTimezoneOffset() * 60000)
+        .toISOString()
+        .split('T')[0];
+    document.getElementById('fechaDesde').value = todayStr;
+    document.getElementById('fechaHasta').value = todayStr;
     applyDateFilter();
 }
 
 function filterThisWeek() {
     const today = new Date();
-    
+
     // Calcular inicio de semana (lunes)
     const dayOfWeek = today.getDay(); // 0 = domingo, 1 = lunes, etc.
     const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek; // Si es domingo, retroceder 6 días
-    
+
     const monday = new Date(today);
     monday.setDate(today.getDate() + mondayOffset);
-    
+
     // Calcular fin de semana (domingo)
     const sunday = new Date(monday);
     sunday.setDate(monday.getDate() + 6);
-    
-    const mondayStr = monday.toISOString().split('T')[0];
-    const sundayStr = sunday.toISOString().split('T')[0];
-    
+
+    const mondayStr = new Date(monday.getTime() - monday.getTimezoneOffset() * 60000)
+        .toISOString()
+        .split('T')[0];
+    const sundayStr = new Date(sunday.getTime() - sunday.getTimezoneOffset() * 60000)
+        .toISOString()
+        .split('T')[0];
+
     document.getElementById('fechaDesde').value = mondayStr;
     document.getElementById('fechaHasta').value = sundayStr;
     applyDateFilter();
@@ -226,21 +238,20 @@ function filterThisMonth() {
     const today = new Date();
     const year = today.getFullYear();
     const month = today.getMonth(); // 0-11
-    
+
     // Primer día del mes
     const firstDay = new Date(year, month, 1);
-    
+
     // Último día del mes
     const lastDay = new Date(year, month + 1, 0);
-    
-    // Ajustar las fechas para evitar desfases por zona horaria
+
     const firstDayStr = new Date(firstDay.getTime() - firstDay.getTimezoneOffset() * 60000)
         .toISOString()
         .split('T')[0];
     const lastDayStr = new Date(lastDay.getTime() - lastDay.getTimezoneOffset() * 60000)
         .toISOString()
         .split('T')[0];
-    
+
     document.getElementById('fechaDesde').value = firstDayStr;
     document.getElementById('fechaHasta').value = lastDayStr;
     applyDateFilter();

--- a/utils/getTodayString.js
+++ b/utils/getTodayString.js
@@ -1,4 +1,6 @@
 export function getTodayString() {
     const today = new Date();
-    return today.toISOString().split('T')[0];
+    return new Date(today.getTime() - today.getTimezoneOffset() * 60000)
+        .toISOString()
+        .split('T')[0];
 }


### PR DESCRIPTION
## Summary
- Add try/catch around `saveDay` storage to surface localStorage failures
- Adjust quick date filters to compute date ranges with timezone offsets and apply filter
- Normalize `getTodayString` to return local date string

## Testing
- `node --experimental-vm-modules node_modules/.bin/jest`

------
https://chatgpt.com/codex/tasks/task_e_68a1435926f483299095b04ec50ba1ae