### PR TITLE
feat: adapt UI to lbj.es color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Caja Diaria">
-    <meta name="theme-color" content="#667eea">
+    <meta name="theme-color" content="#b08d57">
     
     <!-- Icon for iPad home screen -->
     <link rel="apple-touch-icon" sizes="180x180" href="./icon-180.png">

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "description": "Sistema de gestión de caja diaria para sucursales",
   "start_url": "./",
   "display": "standalone",
-  "background_color": "#f8f9fa",
-  "theme_color": "#667eea",
+  "background_color": "#fdf7f2",
+  "theme_color": "#b08d57",
   "icons": [
     {
       "src": "./icon-180.png",

--- a/styles.css
+++ b/styles.css
@@ -4,12 +4,38 @@
     box-sizing: border-box;
 }
 
+:root {
+    --color-primario: #b08d57;
+    --color-primario-oscuro: #a17f4c;
+    --color-secundario: #8c6239;
+    --color-gris: #6c757d;
+    --color-gris-oscuro: #5a6268;
+    --color-exito: #50c878;
+    --color-exito-oscuro: #3ea060;
+    --color-peligro: #e63946;
+    --color-peligro-oscuro: #c2212d;
+    --color-claro: #f8f9fa;
+    --color-borde: #e1e5e9;
+    --color-info-bg: #dbeaf4;
+    --color-exito-bg: #e6f4ea;
+    --color-exito-text: #1f6135;
+    --color-exito-border: #b8dfc1;
+    --color-peligro-bg: #fbeaea;
+    --color-peligro-text: #7b1f24;
+    --color-peligro-border: #f2b6bc;
+    --color-warning-bg: #fff3cd;
+    --color-warning-border: #ffeaa7;
+    --color-info-text: #0b4b56;
+    --color-info-border: #b0d8e3;
+    --color-primario-rgb: 176, 141, 87;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.5;
     color: #333;
-    background-color: #f8f9fa;
+    background-color: var(--color-claro);
 }
 
 .visually-hidden {
@@ -34,7 +60,7 @@ body {
     text-align: center;
     margin-bottom: 30px;
     padding: 20px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--color-primario) 0%, var(--color-secundario) 100%);
     color: white;
     border-radius: 12px;
     box-shadow: 0 4px 15px rgba(0,0,0,0.1);
@@ -65,10 +91,10 @@ body {
 }
 
 .panel h2 {
-    color: #667eea;
+    color: var(--color-primario);
     margin-bottom: 20px;
     font-size: 1.5em;
-    border-bottom: 3px solid #667eea;
+    border-bottom: 3px solid var(--color-primario);
     padding-bottom: 10px;
 }
 
@@ -86,7 +112,7 @@ label {
 input, select, textarea {
     width: 100%;
     padding: 12px 16px;
-    border: 2px solid #e1e5e9;
+    border: 2px solid var(--color-borde);
     border-radius: 8px;
     font-size: 16px;
     transition: border-color 0.3s, box-shadow 0.3s;
@@ -94,8 +120,8 @@ input, select, textarea {
 
 input:focus, select:focus, textarea:focus {
     outline: none;
-    border-color: #667eea;
-    box-shadow: 0 0 0 3px rgba(102,126,234,0.1);
+    border-color: var(--color-primario);
+    box-shadow: 0 0 0 3px rgba(var(--color-primario-rgb),0.1);
 }
 
 .inline-inputs {
@@ -117,40 +143,40 @@ input:focus, select:focus, textarea:focus {
 }
 
 .btn-primary {
-    background: #667eea;
+    background: var(--color-primario);
     color: white;
 }
 
 .btn-primary:hover {
-    background: #5a6fd8;
+    background: var(--color-primario-oscuro);
     transform: translateY(-2px);
 }
 
 .btn-secondary {
-    background: #6c757d;
+    background: var(--color-gris);
     color: white;
 }
 
 .btn-secondary:hover {
-    background: #5a6268;
+    background: var(--color-gris-oscuro);
 }
 
 .btn-success {
-    background: #28a745;
+    background: var(--color-exito);
     color: white;
 }
 
 .btn-success:hover {
-    background: #218838;
+    background: var(--color-exito-oscuro);
 }
 
 .btn-danger {
-    background: #dc3545;
+    background: var(--color-peligro);
     color: white;
 }
 
 .btn-danger:hover {
-    background: #c82333;
+    background: var(--color-peligro-oscuro);
 }
 
 .btn-small {
@@ -167,10 +193,10 @@ input:focus, select:focus, textarea:focus {
 }
 
 .movimientos-container {
-    border: 2px solid #e1e5e9;
+    border: 2px solid var(--color-borde);
     border-radius: 8px;
     padding: 15px;
-    background: #f8f9fa;
+    background: var(--color-claro);
 }
 
 .movimiento-item {
@@ -189,7 +215,7 @@ input:focus, select:focus, textarea:focus {
     flex-direction: column;
     gap: 15px;
     padding: 15px;
-    background: #e3f2fd;
+    background: var(--color-info-bg);
     border-radius: 8px;
     margin-top: 15px;
 }
@@ -227,7 +253,7 @@ input:focus, select:focus, textarea:focus {
         gap: 15px;
         align-items: end;
         padding: 15px;
-        background: #e3f2fd;
+        background: var(--color-info-bg);
         border-radius: 8px;
         margin-top: 15px;
     }
@@ -237,7 +263,7 @@ input:focus, select:focus, textarea:focus {
         font-size: 16px;
         padding: 12px 16px;
         min-height: 44px;
-        border: 2px solid #e1e5e9;
+        border: 2px solid var(--color-borde);
         border-radius: 8px;
         width: 100%;
     }
@@ -296,15 +322,15 @@ input:focus, select:focus, textarea:focus {
 }
 
 .diferencia.cuadra {
-    background: #d4edda;
-    color: #155724;
-    border: 2px solid #c3e6cb;
+    background: var(--color-exito-bg);
+    color: var(--color-exito-text);
+    border: 2px solid var(--color-exito-border);
 }
 
 .diferencia.no-cuadra {
-    background: #f8d7da;
-    color: #721c24;
-    border: 2px solid #f5c6cb;
+    background: var(--color-peligro-bg);
+    color: var(--color-peligro-text);
+    border: 2px solid var(--color-peligro-border);
 }
 
 .table-container {
@@ -324,12 +350,12 @@ table {
 th, td {
     padding: 12px 8px;
     text-align: left;
-    border-bottom: 1px solid #e1e5e9;
+    border-bottom: 1px solid var(--color-borde);
     font-size: 14px;
 }
 
 th {
-    background: #667eea;
+    background: var(--color-primario);
     color: white;
     font-weight: 600;
     position: sticky;
@@ -337,11 +363,11 @@ th {
 }
 
 tr:nth-child(even) {
-    background: #f8f9fa;
+    background: var(--color-claro);
 }
 
 tr:hover {
-    background: #e3f2fd;
+    background: var(--color-info-bg);
 }
 
 .text-right {
@@ -353,7 +379,7 @@ tr:hover {
 }
 
 .filter-section {
-    background: #f8f9fa;
+    background: var(--color-claro);
     padding: 20px;
     border-radius: 8px;
     margin-bottom: 20px;
@@ -361,7 +387,7 @@ tr:hover {
 
 .filter-section h3 {
     margin-bottom: 15px;
-    color: #667eea;
+    color: var(--color-primario);
 }
 
 .filter-quick-buttons {
@@ -372,7 +398,7 @@ tr:hover {
 }
 
 .export-section {
-    background: #e8f5e8;
+    background: var(--color-exito-bg);
     padding: 20px;
     border-radius: 8px;
     margin-top: 20px;
@@ -380,15 +406,15 @@ tr:hover {
 
 .export-section h3 {
     margin-bottom: 15px;
-    color: #28a745;
+    color: var(--color-exito);
 }
 
 .tests-panel {
     position: fixed;
     top: 20px;
     right: 20px;
-    background: #fff3cd;
-    border: 2px solid #ffeaa7;
+    background: var(--color-warning-bg);
+    border: 2px solid var(--color-warning-border);
     border-radius: 8px;
     padding: 15px;
     max-width: 300px;
@@ -407,13 +433,13 @@ tr:hover {
 }
 
 .test-pass {
-    background: #d4edda;
-    color: #155724;
+    background: var(--color-exito-bg);
+    color: var(--color-exito-text);
 }
 
 .test-fail {
-    background: #f8d7da;
-    color: #721c24;
+    background: var(--color-peligro-bg);
+    color: var(--color-peligro-text);
 }
 
 @media (max-width: 1023px) {
@@ -450,7 +476,7 @@ tr:hover {
     right: 16px;
     top: 50%;
     transform: translateY(-50%);
-    color: #6c757d;
+    color: var(--color-gris);
     pointer-events: none;
 }
 
@@ -465,19 +491,19 @@ tr:hover {
 }
 
 .alert-success {
-    background: #d4edda;
-    color: #155724;
-    border: 1px solid #c3e6cb;
+    background: var(--color-exito-bg);
+    color: var(--color-exito-text);
+    border: 1px solid var(--color-exito-border);
 }
 
 .alert-danger {
-    background: #f8d7da;
-    color: #721c24;
-    border: 1px solid #f5c6cb;
+    background: var(--color-peligro-bg);
+    color: var(--color-peligro-text);
+    border: 1px solid var(--color-peligro-border);
 }
 
 .alert-info {
-    background: #d1ecf1;
-    color: #0c5460;
-    border: 1px solid #bee5eb;
+    background: var(--color-info-bg);
+    color: var(--color-info-text);
+    border: 1px solid var(--color-info-border);
 }

--- a/ui.js
+++ b/ui.js
@@ -5,7 +5,7 @@ export function renderMovimientos(movimientos) {
     const container = document.getElementById('movimientosList');
 
     if (!movimientos.length) {
-        container.innerHTML = '<p style="text-align: center; color: #6c757d; padding: 20px;">No hay movimientos registrados</p>';
+        container.innerHTML = '<p style="text-align: center; color: var(--color-gris); padding: 20px;">No hay movimientos registrados</p>';
         return;
     }
 
@@ -50,7 +50,7 @@ export function renderHistorial(filteredDates) {
                 <td class="text-right">${formatCurrency(totals.salidas)} €</td>
                 <td class="text-right">${formatCurrency(totals.total)} €</td>
                 <td class="text-right">${formatCurrency(data.cierre)} €</td>
-                <td class="text-right" style="color: ${Math.abs(totals.diff) < 0.01 ? '#28a745' : '#dc3545'}">${formatCurrency(totals.diff)} €</td>
+                <td class="text-right" style="color: ${Math.abs(totals.diff) < 0.01 ? 'var(--color-exito)' : 'var(--color-peligro)'}">${formatCurrency(totals.diff)} €</td>
                 <td class="text-center">
                     <button class="btn btn-primary btn-small" onclick="editDay('${date}')">✏️</button>
                     <button class="btn btn-danger btn-small" onclick="deleteDayFromHistorial('${date}')">🗑️</button>


### PR DESCRIPTION
## Summary
- replace hard-coded colors with CSS variables for lbj.es palette
- update theme and manifest colors to match new branding
- switch UI scripts to reference the new variables

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a14cf44e3c8329bff14c0497a4417e