### PR TITLE
Update service worker cache version and activation flow

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pwa-cache-v1';
+const CACHE_NAME = 'pwa-cache-v2';
 const PRECACHE_URLS = [
   './',
   './index.html',
@@ -9,6 +9,7 @@ const PRECACHE_URLS = [
 ];
 
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
   );
@@ -16,9 +17,18 @@ self.addEventListener('install', event => {
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
-    )
+    caches.keys()
+      .then(keys =>
+        Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+      )
+      .then(() => {
+        self.clients.claim();
+        return self.clients
+          .matchAll()
+          .then(clients =>
+            Promise.all(clients.map(client => client.navigate(client.url)))
+          );
+      })
   );
 });
 


### PR DESCRIPTION
## Summary
- bump service worker cache name to v2
- force immediate activation with `skipWaiting` and `clients.claim`
- refresh active clients to apply updates

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68a15212dbb08329b2245ca4ade67378