### PR TITLE
Update branding to Gestión de Caja LBJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -454,11 +454,11 @@ function exportCurrentDayEmail() {
     
     // Preparar datos para el email
     const emailTo = 'juanjo@labarberiadejuanjo.com';
-    const emailSubject = `Resumen Caja Diaria - ${sucursal} - ${formatDate(fecha)}`;
+    const emailSubject = `Resumen Caja LBJ - ${sucursal} - ${formatDate(fecha)}`;
     
     const emailBody = `Hola Juanjo,
 
-RESUMEN DE CAJA DIARIA
+RESUMEN DE CAJA LBJ
 Fecha: ${formatDate(fecha)}
 Sucursal: ${sucursal}
 
@@ -492,7 +492,7 @@ Sucursal: ${sucursal}
 
 ═══════════════════════════════════════
 
-Sistema de Gestión de Caja Diaria
+Sistema de Gestión de Caja LBJ
 Generado automáticamente el ${formatDate(new Date().toISOString().split('T')[0])}`;
 
     sendEmail(emailTo, emailSubject, emailBody);
@@ -593,7 +593,7 @@ Días procesados: ${diasProcesados}
 
 ═══════════════════════════════════════
 
-Sistema de Gestión de Caja Diaria
+Sistema de Gestión de Caja LBJ
 Resumen consolidado generado el ${formatDate(new Date().toISOString().split('T')[0])}`;
 
     sendEmail(emailTo, emailSubject, emailBody);
@@ -772,7 +772,7 @@ document.addEventListener('DOMContentLoaded', function() {
     renderHistorial(filteredDates);
     recalc();
     
-    console.log('📊 Sistema de Caja Diaria inicializado correctamente');
+    console.log('📊 Sistema de Caja LBJ inicializado correctamente');
 });
 // Expose functions to global scope
 window.hideTests = hideTests;

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gestión de Caja Diaria</title>
+    <title>Gestión de Caja LBJ</title>
     
     <!-- PWA Meta Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <meta name="apple-mobile-web-app-title" content="Caja Diaria">
+    <meta name="apple-mobile-web-app-title" content="Caja LBJ">
     <meta name="theme-color" content="#b08d57">
     
     <!-- Icon for iPad home screen -->
@@ -24,7 +24,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1>📊 Gestión de Caja Diaria</h1>
+            <h1>📊 Gestión de Caja LBJ</h1>
             <p>Control de efectivo para sucursales</p>
         </div>
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Gestión de Caja Diaria",
-  "short_name": "Caja Diaria",
-  "description": "Sistema de gestión de caja diaria para sucursales",
+  "name": "Gestión de Caja LBJ",
+  "short_name": "Caja LBJ",
+  "description": "Sistema de gestión de caja LBJ para sucursales",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#fdf7f2",


### PR DESCRIPTION
## Summary
- rebrand app to "Gestión de Caja LBJ" in header, title and manifest
- adjust email templates and logs to new name
- add gitignore for node modules

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68a151979b548329b185d089a34cf365