### PR TITLE
fix: use browser API key for saving day

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ if ('serviceWorker' in navigator) {
 // Variables globales
 let currentMovimientos = [];
 let filteredDates = null;
+const API_KEY = globalThis.API_KEY || '';
 
 // Funciones de UI
 function recalc() {
@@ -145,7 +146,7 @@ async function saveDay() {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                Authorization: process.env.API_KEY || ''
+                Authorization: API_KEY
             },
             body: JSON.stringify({
                 cajaDiaria: { ...dayData, movimientos: undefined },


### PR DESCRIPTION
## Summary
- load API key from browser global instead of Node `process` to avoid ReferenceError

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1adf5496c8329a91e09aa8ed9ddbe