### PR TITLE
Implement network-first caching strategy

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pwa-cache-v2';
+const CACHE_NAME = 'pwa-cache-v3';
 const PRECACHE_URLS = [
   './',
   './index.html',
@@ -34,6 +34,14 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    fetch(event.request)
+      .then(networkResponse => {
+        const responseClone = networkResponse.clone();
+        event.waitUntil(
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone))
+        );
+        return networkResponse;
+      })
+      .catch(() => caches.match(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- switch service worker to network-first strategy and update cache name

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b328e20c832984ee2bab4588481f