### PR TITLE
feat: auto update service worker

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,19 @@ import { parseNum, formatCurrency, formatDate, getTodayString, computeTotals } f
 import { getDayIndex, loadDay, saveDayData, deleteDay } from "./storage.js";
 import { renderMovimientos, renderHistorial, showAlert, displayTestResults, hideTests } from "./ui.js";
 if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('./service-worker.js');
+    navigator.serviceWorker.register('./service-worker.js', { updateViaCache: 'none' }).then(registration => {
+        registration.update();
+        registration.addEventListener('updatefound', () => {
+            const newWorker = registration.installing;
+            if (newWorker) {
+                newWorker.addEventListener('statechange', () => {
+                    if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                        window.location.reload();
+                    }
+                });
+            }
+        });
+    });
 }
 
 // Variables globales


### PR DESCRIPTION
## Summary
- force service worker to bypass cache when checking for updates
- auto refresh page once new service worker is installed

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b44d349883298637cab79b392448