### PR TITLE
fix: parse JSON body strings

### DIFF
--- a/api/save-day.js
+++ b/api/save-day.js
@@ -26,6 +26,9 @@ export default async function handler(req, res) {
   let body;
   try {
     body = req.body;
+    if (typeof body === 'string') {
+      body = JSON.parse(body);
+    }
     if (!body) {
       const chunks = [];
       for await (const chunk of req) {


### PR DESCRIPTION
## Summary
- handle JSON string bodies in save-day API

## Testing
- `npm test` *(fails: Jest failed to parse ES modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b8656fe88329812761b7b3b08df8