### PR TITLE
Skip server save without API key and enable ESM tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,24 +154,28 @@ async function saveDay() {
     try {
         saveDayData(fecha, dayData);
 
-        const response = await fetch('/api/save-day', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: API_KEY
-            },
-            body: JSON.stringify({
-                cajaDiaria: { ...dayData, movimientos: undefined },
-                movimientos: currentMovimientos
-            })
-        });
+        if (API_KEY) {
+            const response = await fetch('/api/save-day', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: API_KEY
+                },
+                body: JSON.stringify({
+                    cajaDiaria: { ...dayData, movimientos: undefined },
+                    movimientos: currentMovimientos
+                })
+            });
 
-        const result = await response.json();
+            const result = await response.json();
 
-        if (result.success) {
-            showAlert('Día guardado correctamente', 'success');
+            if (result.success) {
+                showAlert('Día guardado correctamente', 'success');
+            } else {
+                showAlert('Error al guardar el día en el servidor', 'danger');
+            }
         } else {
-            showAlert('Error al guardar el día en el servidor', 'danger');
+            showAlert('Día guardado localmente (sin API key)', 'info');
         }
 
         renderHistorial(filteredDates);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "type": "module",
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "pg": "^8.11.3"


### PR DESCRIPTION
## Summary
- Avoid sending save-day requests when API key is not set and show informational alert
- Run Jest using Node's vm modules to support ES modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1badb2b708329867e0efd36b53f09