### PR TITLE
Recordar sucursal en la PWA

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,34 @@ let currentMovimientos = [];
 let filteredDates = null;
 const API_KEY = globalThis.API_KEY || '';
 
+function applySucursal() {
+    const saved = localStorage.getItem('sucursal');
+    const select = document.getElementById('sucursal');
+    if (saved && select) {
+        select.value = saved;
+        select.disabled = true;
+    }
+}
+
+function initializeSucursal() {
+    const saved = localStorage.getItem('sucursal');
+    if (saved) {
+        applySucursal();
+    } else {
+        const modal = document.getElementById('sucursalSetup');
+        const saveBtn = document.getElementById('guardarSucursal');
+        if (modal && saveBtn) {
+            modal.style.display = 'flex';
+            saveBtn.addEventListener('click', () => {
+                const selected = document.getElementById('sucursalInicial').value;
+                localStorage.setItem('sucursal', selected);
+                modal.style.display = 'none';
+                applySucursal();
+            }, { once: true });
+        }
+    }
+}
+
 // Funciones de UI
 function recalc() {
     const apertura = document.getElementById('apertura').value;
@@ -103,6 +131,7 @@ function clearForm() {
     document.getElementById('fecha').value = getTodayString();
     currentMovimientos = [];
     renderMovimientos(currentMovimientos);
+    applySucursal();
     recalc();
 }
 
@@ -116,9 +145,10 @@ function loadFormData(data) {
     document.getElementById('ingresosTarjetaDatafono').value = formatCurrency(data.ingresosTarjetaDatafono || 0);
     document.getElementById('cierre').value = formatCurrency(data.cierre);
     document.getElementById('responsableCierre').value = data.responsableCierre;
-    
+
     currentMovimientos = data.movimientos || [];
     renderMovimientos(currentMovimientos);
+    applySucursal();
     recalc();
 }
 
@@ -756,6 +786,7 @@ function runTests() {
 document.addEventListener('DOMContentLoaded', function() {
     // Configurar fecha por defecto
     document.getElementById('fecha').value = getTodayString();
+    initializeSucursal();
     
     // Event listeners para recálculo automático
     ['apertura', 'ingresos', 'ingresosTarjetaExora', 'ingresosTarjetaDatafono', 'cierre'].forEach(id => {

--- a/index.html
+++ b/index.html
@@ -22,6 +22,16 @@
 
 </head>
 <body>
+    <div id="sucursalSetup" class="modal-overlay">
+        <div class="modal-content">
+            <h2>Selecciona la barbería</h2>
+            <select id="sucursalInicial">
+                <option value="Lliçà d'Amunt">Lliçà d'Amunt</option>
+                <option value="Parets del Vallès">Parets del Vallès</option>
+            </select>
+            <button id="guardarSucursal" class="btn btn-primary">Guardar</button>
+        </div>
+    </div>
     <div class="container">
         <div class="header">
             <h1>📊 Gestión de Caja LBJ</h1>

--- a/styles.css
+++ b/styles.css
@@ -517,3 +517,25 @@ tr:hover {
     color: var(--color-info-text);
     border: 1px solid var(--color-info-border);
 }
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+.modal-content {
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+    width: 90%;
+    max-width: 400px;
+}


### PR DESCRIPTION
## Summary
- Agrega un modal inicial para elegir la barbería y guardarla en localStorage
- Deshabilita el selector de sucursal y lo aplica automáticamente al cargar o limpiar el formulario
- Estilos básicos para el modal de selección

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bedb9aec8329a76a603dcc65b8d0