### PR TITLE
Add branch-specific staff dropdowns

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,31 @@ let currentMovimientos = [];
 let filteredDates = null;
 const API_KEY = globalThis.API_KEY || '';
 
+const empleadosPorSucursal = {
+    "Lliçà d'Amunt": ["Juanjo", "Jordi", "Ian Paul", "Miquel"],
+    "Parets del Vallès": ["Juanjo", "Quim", "Genís", "Alex"]
+};
+
+function updateResponsables() {
+    const sucursal = document.getElementById('sucursal')?.value;
+    const nombres = empleadosPorSucursal[sucursal] || [];
+    const placeholders = {
+        responsableApertura: 'Seleccionar responsable',
+        responsableCierre: 'Seleccionar responsable',
+        quienMovimiento: 'Quién realizó'
+    };
+    ['responsableApertura', 'responsableCierre', 'quienMovimiento'].forEach(id => {
+        const select = document.getElementById(id);
+        if (!select) return;
+        const current = select.value;
+        select.innerHTML = `<option value="">${placeholders[id]}</option>` +
+            nombres.map(nombre => `<option value="${nombre}">${nombre}</option>`).join('');
+        if (nombres.includes(current)) {
+            select.value = current;
+        }
+    });
+}
+
 function applySucursal() {
     const saved = localStorage.getItem('sucursal');
     const select = document.getElementById('sucursal');
@@ -29,6 +54,7 @@ function applySucursal() {
         select.value = saved;
         select.disabled = true;
     }
+    updateResponsables();
 }
 
 function openSucursalModal() {
@@ -176,6 +202,7 @@ function clearForm() {
 function loadFormData(data) {
     document.getElementById('fecha').value = data.fecha;
     document.getElementById('sucursal').value = data.sucursal;
+    applySucursal();
     document.getElementById('apertura').value = formatCurrency(data.apertura);
     document.getElementById('responsableApertura').value = data.responsableApertura;
     document.getElementById('ingresos').value = formatCurrency(data.ingresos);
@@ -186,7 +213,6 @@ function loadFormData(data) {
 
     currentMovimientos = data.movimientos || [];
     renderMovimientos(currentMovimientos);
-    applySucursal();
     recalc();
 }
 
@@ -826,7 +852,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // Configurar fecha por defecto
     document.getElementById('fecha').value = getTodayString();
     initializeSucursal();
-    
+    updateResponsables();
+
     // Event listeners para recálculo automático
     ['apertura', 'ingresos', 'ingresosTarjetaExora', 'ingresosTarjetaDatafono', 'cierre'].forEach(id => {
         const element = document.getElementById(id);
@@ -836,9 +863,14 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
-    ['responsableApertura', 'responsableCierre', 'sucursal'].forEach(id => {
+    ['responsableApertura', 'responsableCierre'].forEach(id => {
         const element = document.getElementById(id);
         element.addEventListener('input', saveDraft);
+    });
+    const sucursalSelect = document.getElementById('sucursal');
+    sucursalSelect.addEventListener('change', () => {
+        updateResponsables();
+        saveDraft();
     });
     
     // Event listener para cambio de fecha

--- a/index.html
+++ b/index.html
@@ -75,7 +75,9 @@
                         
                         <div class="form-group">
                             <label for="responsableApertura">Responsable apertura</label>
-                            <input type="text" id="responsableApertura" placeholder="Nombre del responsable">
+                            <select id="responsableApertura">
+                                <option value="">Seleccionar responsable</option>
+                            </select>
                         </div>
                     </div>
 
@@ -108,7 +110,9 @@
                                     <option value="salida">Salida</option>
                                 </select>
                                 <label for="quienMovimiento" class="visually-hidden">Quién realizó</label>
-                                <input type="text" id="quienMovimiento" placeholder="Quién realizó" tabindex="0">
+                                <select id="quienMovimiento" tabindex="0">
+                                    <option value="">Quién realizó</option>
+                                </select>
                                 <label for="importeMovimiento" class="visualmente-hidden">Importe del movimiento</label>
                                 <input type="text" id="importeMovimiento" placeholder="0,00" inputmode="decimal" tabindex="0">
                                 <button type="button" class="btn btn-primary btn-small" onclick="addMovimiento()" tabindex="0">+</button>
@@ -124,7 +128,9 @@
                         
                         <div class="form-group">
                             <label for="responsableCierre">Responsable cierre</label>
-                            <input type="text" id="responsableCierre" placeholder="Nombre del responsable">
+                            <select id="responsableCierre">
+                                <option value="">Seleccionar responsable</option>
+                            </select>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Add staff lists per branch and auto-populate responsible fields and treasury movement selector
- Convert responsible name inputs to dropdowns filtered by selected branch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cc4691c88329b5d6abca29070d86