### PR TITLE
Alinear labels y ubicar símbolo € dentro de los campos

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,9 +68,11 @@
                     </div>
 
                     <div class="inline-inputs">
-                        <div class="form-group currency">
+                        <div class="form-group">
                             <label for="apertura">Apertura de caja</label>
-                            <input type="text" id="apertura" placeholder="0,00" inputmode="decimal">
+                            <div class="currency">
+                                <input type="text" id="apertura" placeholder="0,00" inputmode="decimal">
+                            </div>
                         </div>
                         
                         <div class="form-group">
@@ -81,20 +83,26 @@
                         </div>
                     </div>
 
-                    <div class="form-group currency">
+                    <div class="form-group">
                         <label for="ingresos">Ingresos en efectivo (Exora)</label>
-                        <input type="text" id="ingresos" placeholder="0,00" inputmode="decimal">
+                        <div class="currency">
+                            <input type="text" id="ingresos" placeholder="0,00" inputmode="decimal">
+                        </div>
                     </div>
 
                     <div class="inline-inputs">
-                        <div class="form-group currency">
+                        <div class="form-group">
                             <label for="ingresosTarjetaExora">Ingresos en tarjeta (Exora)</label>
-                            <input type="text" id="ingresosTarjetaExora" placeholder="0,00" inputmode="decimal">
+                            <div class="currency">
+                                <input type="text" id="ingresosTarjetaExora" placeholder="0,00" inputmode="decimal">
+                            </div>
                         </div>
-                        
-                        <div class="form-group currency">
+
+                        <div class="form-group">
                             <label for="ingresosTarjetaDatafono">Ingresos en tarjeta (Datáfono)</label>
-                            <input type="text" id="ingresosTarjetaDatafono" placeholder="0,00" inputmode="decimal">
+                            <div class="currency">
+                                <input type="text" id="ingresosTarjetaDatafono" placeholder="0,00" inputmode="decimal">
+                            </div>
                         </div>
                     </div>
 
@@ -113,17 +121,21 @@
                                 <select id="quienMovimiento" tabindex="0">
                                     <option value="">Quién realizó</option>
                                 </select>
-                                <label for="importeMovimiento" class="visualmente-hidden">Importe del movimiento</label>
-                                <input type="text" id="importeMovimiento" placeholder="0,00" inputmode="decimal" tabindex="0">
+                                <label for="importeMovimiento" class="visually-hidden">Importe del movimiento</label>
+                                <div class="currency">
+                                    <input type="text" id="importeMovimiento" placeholder="0,00" inputmode="decimal" tabindex="0">
+                                </div>
                                 <button type="button" class="btn btn-primary btn-small" onclick="addMovimiento()" tabindex="0">+</button>
                             </div>
                         </div>
                     </fieldset>
 
                     <div class="inline-inputs">
-                        <div class="form-group currency">
+                        <div class="form-group">
                             <label for="cierre">Cierre de caja</label>
-                            <input type="text" id="cierre" placeholder="0,00" inputmode="decimal">
+                            <div class="currency">
+                                <input type="text" id="cierre" placeholder="0,00" inputmode="decimal">
+                            </div>
                         </div>
                         
                         <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -141,7 +141,7 @@ input:focus, select:focus, textarea:focus {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 15px;
-    align-items: end;
+    align-items: start;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- Alinear los campos "Fecha" y "Sucursal" con `align-items: start`
- Envolver los campos monetarios en contenedores `.currency` para mostrar el símbolo € dentro de los inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cf30264083299620e4ae30867b1f