### PR TITLE
feat: refresh UI theme with blue palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Caja LBJ">
-    <meta name="theme-color" content="#b08d57">
+    <meta name="theme-color" content="#5865f2">
     
     <!-- Icon for iPad home screen -->
     <link rel="apple-touch-icon" sizes="180x180" href="./icon-180.png">
@@ -17,7 +17,10 @@
     
     <!-- Manifest for PWA -->
     <link rel="manifest" href="./manifest.json">
-    
+
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
     <link rel="stylesheet" href="styles.css?v=2">
 
 </head>

--- a/styles.css
+++ b/styles.css
@@ -5,16 +5,16 @@
 }
 
 :root {
-    --color-primario: #b08d57;
-    --color-primario-oscuro: #a17f4c;
-    --color-secundario: #8c6239;
+    --color-primario: #5865f2;
+    --color-primario-oscuro: #3d4ae0;
+    --color-secundario: #7789ff;
     --color-gris: #6c757d;
     --color-gris-oscuro: #5a6268;
     --color-exito: #50c878;
     --color-exito-oscuro: #3ea060;
     --color-peligro: #e63946;
     --color-peligro-oscuro: #c2212d;
-    --color-claro: #f8f9fa;
+    --color-claro: #f8faff;
     --color-borde: #e1e5e9;
     --color-info-bg: #dbeaf4;
     --color-exito-bg: #e6f4ea;
@@ -27,11 +27,11 @@
     --color-warning-border: #ffeaa7;
     --color-info-text: #0b4b56;
     --color-info-border: #b0d8e3;
-    --color-primario-rgb: 176, 141, 87;
+    --color-primario-rgb: 88, 101, 242;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.5;
     color: #333;


### PR DESCRIPTION
## Summary
- apply blue gradient styling and Poppins font to match reference aesthetic
- update theme color and palette variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1d39756808329920741122b1cef8f