### PR TITLE
Allow multiple cash closures per day

### DIFF
--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,0 +1,40 @@
+import { describe, beforeEach, test, expect } from '@jest/globals';
+import { saveDayData, loadDay, getDayIndex, deleteDay } from '../storage.js';
+
+let store = {};
+
+beforeEach(() => {
+  store = {};
+  global.localStorage = {
+    setItem: (k, v) => { store[k] = v; },
+    getItem: (k) => store[k] || null,
+    removeItem: (k) => { delete store[k]; }
+  };
+});
+
+describe('saveDayData with multiple closings per day', () => {
+  test('creates unique keys for same date', () => {
+    const key1 = saveDayData('2024-01-01', { cierre: 100 });
+    const key2 = saveDayData('2024-01-01', { cierre: 200 });
+    expect(key1).not.toBe(key2);
+    expect(getDayIndex()).toHaveLength(2);
+    expect(loadDay(key1).cierre).toBe(100);
+    expect(loadDay(key2).cierre).toBe(200);
+  });
+
+  test('allows updating existing key', () => {
+    const key1 = saveDayData('2024-01-01', { cierre: 100 });
+    const keyUpdated = saveDayData('2024-01-01', { cierre: 150 }, key1);
+    expect(keyUpdated).toBe(key1);
+    expect(getDayIndex()).toHaveLength(1);
+    expect(loadDay(key1).cierre).toBe(150);
+  });
+
+  test('deleteDay removes entry and index', () => {
+    const key = saveDayData('2024-01-01', { cierre: 100 });
+    deleteDay(key);
+    expect(getDayIndex()).toHaveLength(0);
+    expect(loadDay(key)).toBeNull();
+  });
+});
+

--- a/storage.js
+++ b/storage.js
@@ -17,12 +17,12 @@ export function updateDayIndex(date, action = 'add') {
     if (action === 'add') {
         if (!index.includes(date)) {
             index.push(date);
-            index.sort();
         }
     } else if (action === 'remove') {
         index = index.filter(d => d !== date);
     }
 
+    index.sort((a, b) => a.localeCompare(b));
     saveToLocalStorage('caja:index', index);
 }
 
@@ -30,9 +30,29 @@ export function loadDay(date) {
     return getFromLocalStorage(`caja:${date}`);
 }
 
-export function saveDayData(date, data) {
-    saveToLocalStorage(`caja:${date}`, data);
-    updateDayIndex(date, 'add');
+export function saveDayData(date, data, existingKey = null) {
+    let key = existingKey;
+
+    if (existingKey) {
+        if (existingKey.startsWith(date)) {
+            saveToLocalStorage(`caja:${existingKey}`, data);
+            updateDayIndex(existingKey, 'add');
+            return existingKey;
+        } else {
+            deleteDay(existingKey);
+            key = null;
+        }
+    }
+
+    if (!key) {
+        const index = getDayIndex();
+        const count = index.filter(d => d.startsWith(date)).length;
+        key = `${date}#${count + 1}`;
+    }
+
+    saveToLocalStorage(`caja:${key}`, data);
+    updateDayIndex(key, 'add');
+    return key;
 }
 
 export function deleteDay(date) {

--- a/ui.js
+++ b/ui.js
@@ -24,7 +24,10 @@ export function renderHistorial(filteredDates) {
     let dates = getDayIndex();
 
     if (filteredDates) {
-        dates = dates.filter(date => date >= filteredDates.desde && date <= filteredDates.hasta);
+        dates = dates.filter(date => {
+            const day = date.split('#')[0];
+            return day >= filteredDates.desde && day <= filteredDates.hasta;
+        });
     }
 
     if (!dates.length) {
@@ -32,17 +35,24 @@ export function renderHistorial(filteredDates) {
         return;
     }
 
-    dates.sort((a, b) => b.localeCompare(a));
+    dates.sort((a, b) => {
+        const [dateA, turnoA] = a.split('#');
+        const [dateB, turnoB] = b.split('#');
+        if (dateA === dateB) {
+            return Number(turnoB || 0) - Number(turnoA || 0);
+        }
+        return dateB.localeCompare(dateA);
+    });
 
     tbody.innerHTML = dates.map(date => {
         const data = loadDay(date);
         if (!data) return '';
-
+        const [day, turno] = date.split('#');
         const totals = computeTotals(data.apertura, data.ingresos, data.movimientos, data.cierre);
 
         return `
             <tr>
-                <td>${formatDate(date)}</td>
+                <td>${formatDate(day)}${turno ? ` (Turno ${turno})` : ''}</td>
                 <td>${data.sucursal}</td>
                 <td class="text-right">${formatCurrency(data.apertura)} €</td>
                 <td class="text-right">${formatCurrency(data.ingresos)} €</td>

--- a/utils/formatDate.js
+++ b/utils/formatDate.js
@@ -1,4 +1,5 @@
 export function formatDate(dateStr) {
-    const date = new Date(dateStr + 'T00:00:00');
+    const base = dateStr.split('T')[0].split('#')[0];
+    const date = new Date(base + 'T00:00:00');
     return date.toLocaleDateString('es-ES');
 }


### PR DESCRIPTION
## Summary
- Store daily cash records with unique keys to support multiple closures on the same date
- Show each closure separately in history with turno indicator and handle edits/deletions by key
- Add unit tests for storage to ensure unique keys and updating behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a21d4f692c8329bb87c782960664f0