### PR TITLE
Registrar hora de guardado de cierres

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -133,3 +133,36 @@ describe('changeSucursal', () => {
         expect(elements.sucursalSetup.style.display).toBe('none');
     });
 });
+
+describe('saveDay', () => {
+    let elements;
+    beforeEach(() => {
+        store = {};
+        global.localStorage.setItem.mockImplementation((k, v) => { store[k] = v; });
+        global.localStorage.getItem.mockImplementation((k) => store[k] || null);
+        global.localStorage.removeItem.mockImplementation((k) => { delete store[k]; });
+        elements = {
+            fecha: { value: '2025-01-01' },
+            sucursal: { value: 'Central' },
+            apertura: { value: '0' },
+            responsableApertura: { value: '' },
+            ingresos: { value: '0' },
+            ingresosTarjetaExora: { value: '0' },
+            ingresosTarjetaDatafono: { value: '0' },
+            cierre: { value: '0' },
+            responsableCierre: { value: '' }
+        };
+        global.document = {
+            getElementById: (id) => elements[id],
+            addEventListener: jest.fn()
+        };
+    });
+
+    test('saveDay almacena hora de guardado', async () => {
+        await window.saveDay();
+        const index = JSON.parse(store['caja:index']);
+        const key = index[0];
+        const saved = JSON.parse(store[`caja:${key}`]);
+        expect(saved.horaGuardado).toBeDefined();
+    });
+});

--- a/app.js
+++ b/app.js
@@ -244,7 +244,8 @@ async function saveDay() {
         ingresosTarjetaDatafono,
         movimientos: [...currentMovimientos],
         cierre,
-        responsableCierre
+        responsableCierre,
+        horaGuardado: new Date().toISOString()
     };
 
     try {
@@ -457,7 +458,7 @@ function exportCombinedCSV() {
     
     // Generar contenido de caja
     const cajaHeaders = [
-        'Fecha', 'Sucursal', 'Apertura de caja (€)', 'Responsable apertura de caja',
+        'Fecha', 'Hora', 'Sucursal', 'Apertura de caja (€)', 'Responsable apertura de caja',
         'Ingresos en efectivo (€)', 'Gestión de tesorería (salidas)', 'Gestión de tesorería (entradas)',
         'Total en caja', 'Cierre de caja', 'Diferencia', 'Responsable de cierre de caja'
     ];
@@ -468,7 +469,7 @@ function exportCombinedCSV() {
         if (dayData) {
             const totals = computeTotals(dayData.apertura, dayData.ingresos, dayData.movimientos, dayData.cierre);
             cajaData.push([
-                formatDate(date), dayData.sucursal, dayData.apertura, dayData.responsableApertura,
+                formatDate(date), dayData.horaGuardado ? new Date(dayData.horaGuardado).toLocaleTimeString('es-ES') : '', dayData.sucursal, dayData.apertura, dayData.responsableApertura,
                 dayData.ingresos, totals.salidas, totals.entradas, totals.total,
                 dayData.cierre, totals.diff, dayData.responsableCierre
             ]);

--- a/index.html
+++ b/index.html
@@ -199,6 +199,7 @@
                         <thead>
                             <tr>
                                 <th>Fecha</th>
+                                <th>Hora</th>
                                 <th>Sucursal</th>
                                 <th class="text-right">Apertura</th>
                                 <th class="text-right">Ingresos</th>

--- a/ui.js
+++ b/ui.js
@@ -31,7 +31,7 @@ export function renderHistorial(filteredDates) {
     }
 
     if (!dates.length) {
-        tbody.innerHTML = '<tr><td colspan="10" class="text-center">No hay datos para mostrar</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="11" class="text-center">No hay datos para mostrar</td></tr>';
         return;
     }
 
@@ -50,9 +50,12 @@ export function renderHistorial(filteredDates) {
         const [day, turno] = date.split('#');
         const totals = computeTotals(data.apertura, data.ingresos, data.movimientos, data.cierre);
 
+        const hora = data.horaGuardado ? new Date(data.horaGuardado).toLocaleTimeString('es-ES') : '';
+
         return `
             <tr>
                 <td>${formatDate(day)}${turno ? ` (Turno ${turno})` : ''}</td>
+                <td>${hora}</td>
                 <td>${data.sucursal}</td>
                 <td class="text-right">${formatCurrency(data.apertura)} €</td>
                 <td class="text-right">${formatCurrency(data.ingresos)} €</td>


### PR DESCRIPTION
## Resumen
- Guarda la hora al almacenar un cierre de caja
- Muestra la hora en el historial de cierres y en la exportación CSV
- Añade prueba automática para verificar que se registra la hora

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21fb2654483298bdc7d464f4954d5