### PR TITLE
feat: add dropdown actions for daily records

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -553,3 +553,43 @@ tr:hover {
     width: 90%;
     max-width: 400px;
 }
+
+/* Dropdown de acciones en historial */
+.actions-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-menu {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    background: white;
+    border: 1px solid var(--color-borde);
+    border-radius: 6px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    display: none;
+    min-width: 160px;
+    z-index: 100;
+}
+
+.dropdown-menu.show {
+    display: block;
+}
+
+.dropdown-menu button {
+    width: 100%;
+    padding: 8px 12px;
+    border: none;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+}
+
+.dropdown-menu button:hover {
+    background: var(--color-claro);
+}
+
+.dropdown-menu button.delete {
+    color: var(--color-peligro);
+}

--- a/ui.js
+++ b/ui.js
@@ -51,6 +51,7 @@ export function renderHistorial(filteredDates) {
         const totals = computeTotals(data.apertura, data.ingresos, data.movimientos, data.cierre);
 
         const hora = data.horaGuardado ? new Date(data.horaGuardado).toLocaleTimeString('es-ES') : '';
+        const safeId = date.replace(/[^a-z0-9]/gi, '_');
 
         return `
             <tr>
@@ -65,8 +66,15 @@ export function renderHistorial(filteredDates) {
                 <td class="text-right">${formatCurrency(data.cierre)} €</td>
                 <td class="text-right" style="color: ${Math.abs(totals.diff) < 0.01 ? 'var(--color-exito)' : 'var(--color-peligro)'}">${formatCurrency(totals.diff)} €</td>
                 <td class="text-center">
-                    <button class="btn btn-primary btn-small" onclick="editDay('${date}')">✏️</button>
-                    <button class="btn btn-danger btn-small" onclick="deleteDayFromHistorial('${date}')">🗑️</button>
+                    <div class="actions-dropdown">
+                        <button class="btn btn-secondary btn-small" onclick="toggleActionsMenu('actions-${safeId}')">⋮</button>
+                        <div id="actions-${safeId}" class="dropdown-menu">
+                            <button onclick="editDay('${date}')">Editar</button>
+                            <button onclick="emailDay('${date}')">Enviar por email</button>
+                            <button onclick="downloadDayCSV('${date}')">Descargar CSV</button>
+                            <button class="delete" onclick="deleteDayFromHistorial('${date}')">Eliminar</button>
+                        </div>
+                    </div>
                 </td>
             </tr>
         `;


### PR DESCRIPTION
## Summary
- add actions dropdown with edit/email/csv/delete options for each day
- implement per-day email and CSV export helpers
- style dropdown menu for actions column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22641298c83298bbd4b296949b5c3