### PR TITLE
Cerrar menús de acciones al seleccionar opciones

### DIFF
--- a/app.js
+++ b/app.js
@@ -835,10 +835,20 @@ function sendEmail(emailTo, emailSubject, emailBody) {
     }
 }
 
+function closeAllActionsMenus() {
+    document
+        .querySelectorAll('.dropdown-menu.show')
+        .forEach(menu => menu.classList.remove('show'));
+}
+
 function toggleActionsMenu(id) {
     const menu = document.getElementById(id);
     if (menu) {
-        menu.classList.toggle('show');
+        const isOpen = menu.classList.contains('show');
+        closeAllActionsMenus();
+        if (!isOpen) {
+            menu.classList.add('show');
+        }
     }
 }
 
@@ -1036,3 +1046,4 @@ window.changeSucursal = changeSucursal;
 window.downloadDayCSV = downloadDayCSV;
 window.emailDay = emailDay;
 window.toggleActionsMenu = toggleActionsMenu;
+window.closeAllActionsMenus = closeAllActionsMenus;

--- a/ui.js
+++ b/ui.js
@@ -69,10 +69,10 @@ export function renderHistorial(filteredDates) {
                     <div class="actions-dropdown">
                         <button class="btn btn-secondary btn-small" onclick="toggleActionsMenu('actions-${safeId}')">⋮</button>
                         <div id="actions-${safeId}" class="dropdown-menu">
-                            <button onclick="editDay('${date}')">Editar</button>
-                            <button onclick="emailDay('${date}')">Enviar por email</button>
-                            <button onclick="downloadDayCSV('${date}')">Descargar CSV</button>
-                            <button class="delete" onclick="deleteDayFromHistorial('${date}')">Eliminar</button>
+                            <button onclick="closeAllActionsMenus(); editDay('${date}')">Editar</button>
+                            <button onclick="closeAllActionsMenus(); emailDay('${date}')">Enviar por email</button>
+                            <button onclick="closeAllActionsMenus(); downloadDayCSV('${date}')">Descargar CSV</button>
+                            <button class="delete" onclick="closeAllActionsMenus(); deleteDayFromHistorial('${date}')">Eliminar</button>
                         </div>
                     </div>
                 </td>


### PR DESCRIPTION
## Summary
- cierran los menús abiertos al cambiar entre registros
- las acciones del menú cierran automáticamente el desplegable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2283a213883298342318fe42632f3