### PR TITLE
fix: ensure actions menu overlays table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -359,6 +359,7 @@ input:focus, select:focus, textarea:focus {
 
 .table-container {
     overflow-x: auto;
+    overflow-y: visible;
     margin: 20px 0;
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- keep historial actions dropdown fully visible by allowing vertical overflow in table container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a229e81b748329b13857480ff22882