### PR TITLE
Fix overflow of actions dropdown menu

### DIFF
--- a/__tests__/dropdown.test.js
+++ b/__tests__/dropdown.test.js
@@ -1,0 +1,51 @@
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
+
+let menu;
+
+describe('toggleActionsMenu positioning', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+
+    menu = {
+      _classList: new Set(),
+      classList: {
+        contains: cls => menu._classList.has(cls),
+        add: cls => menu._classList.add(cls),
+        remove: cls => menu._classList.delete(cls)
+      },
+      style: {},
+      getBoundingClientRect: jest.fn(() => ({ bottom: window.innerHeight + 10 }))
+    };
+
+    global.window = { innerHeight: 600 };
+    global.document = {
+      getElementById: jest.fn(() => menu),
+      querySelectorAll: jest.fn(() => []),
+      addEventListener: jest.fn()
+    };
+
+    jest.unstable_mockModule('../ui.js', () => ({
+      renderMovimientos: jest.fn(),
+      renderHistorial: jest.fn(),
+      showAlert: jest.fn(),
+      displayTestResults: jest.fn(),
+      hideTests: jest.fn()
+    }));
+
+    jest.unstable_mockModule('../utils/index.js', () => ({
+      parseNum: jest.fn(() => 0),
+      formatCurrency: jest.fn(v => v),
+      formatDate: jest.fn(),
+      getTodayString: jest.fn(() => '2025-01-01'),
+      computeTotals: jest.fn(() => ({ diff: 0 }))
+    }));
+
+    await import('../app.js');
+  });
+
+  test('positions menu above when it would overflow', () => {
+    window.toggleActionsMenu('test');
+    expect(menu.style.bottom).toBe('100%');
+    expect(menu.style.top).toBe('auto');
+  });
+});

--- a/app.js
+++ b/app.js
@@ -838,7 +838,11 @@ function sendEmail(emailTo, emailSubject, emailBody) {
 function closeAllActionsMenus() {
     document
         .querySelectorAll('.dropdown-menu.show')
-        .forEach(menu => menu.classList.remove('show'));
+        .forEach(menu => {
+            menu.classList.remove('show');
+            menu.style.top = '';
+            menu.style.bottom = '';
+        });
 }
 
 function toggleActionsMenu(id) {
@@ -848,6 +852,14 @@ function toggleActionsMenu(id) {
         closeAllActionsMenus();
         if (!isOpen) {
             menu.classList.add('show');
+            const rect = menu.getBoundingClientRect();
+            if (rect.bottom > window.innerHeight) {
+                menu.style.top = 'auto';
+                menu.style.bottom = '100%';
+            } else {
+                menu.style.top = '';
+                menu.style.bottom = '';
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent actions menu from being hidden by repositioning above when it would overflow the viewport
- add unit test for dropdown positioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22b7bd8608329883b0a73d0c721c4