### PR TITLE
Invert cash difference sign and color coding

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -26,11 +26,11 @@ describe('computeTotals', () => {
             { tipo: 'entrada', importe: 2 }
         ];
         const result = computeTotals(100, 50, movimientos, 120);
-        expect(result).toEqual({ entradas: 12, salidas: 5, total: 157, diff: 37 });
+        expect(result).toEqual({ entradas: 12, salidas: 5, total: 157, diff: -37 });
     });
 
     test('handles string numbers and empty movimientos', () => {
         const result = computeTotals('1.000,00', '200,00', [], '800');
-        expect(result).toEqual({ entradas: 0, salidas: 0, total: 1200, diff: 400 });
+        expect(result).toEqual({ entradas: 0, salidas: 0, total: 1200, diff: -400 });
     });
 });

--- a/app.js
+++ b/app.js
@@ -124,13 +124,15 @@ function recalc() {
     const diferenciaDiv = document.getElementById('diferenciaDisplay');
     if (diferenciaDiv) {
         const diffFormatted = formatCurrency(totals.diff);
-
         if (Math.abs(totals.diff) < 0.01) {
-            diferenciaDiv.className = 'diferencia cuadra';
+            diferenciaDiv.className = 'diferencia cero';
             diferenciaDiv.innerHTML = `✅ Diferencia Efectivo: ${diffFormatted} € - ¡Cuadra!`;
+        } else if (totals.diff > 0) {
+            diferenciaDiv.className = 'diferencia positivo';
+            diferenciaDiv.innerHTML = `⚠️ Diferencia Efectivo: ${diffFormatted} € - Sobra dinero`;
         } else {
-            diferenciaDiv.className = 'diferencia no-cuadra';
-            diferenciaDiv.innerHTML = `⚠️ Diferencia Efectivo: ${diffFormatted} € - No cuadra`;
+            diferenciaDiv.className = 'diferencia negativo';
+            diferenciaDiv.innerHTML = `⚠️ Diferencia Efectivo: ${diffFormatted} € - Falta dinero`;
         }
     }
     

--- a/styles.css
+++ b/styles.css
@@ -345,6 +345,24 @@ input:focus, select:focus, textarea:focus {
     margin: 20px 0;
 }
 
+.diferencia.cero {
+    background: var(--color-exito-bg);
+    color: var(--color-exito-text);
+    border: 2px solid var(--color-exito-border);
+}
+
+.diferencia.positivo {
+    background: var(--color-info-bg);
+    color: var(--color-info-text);
+    border: 2px solid var(--color-info-border);
+}
+
+.diferencia.negativo {
+    background: var(--color-peligro-bg);
+    color: var(--color-peligro-text);
+    border: 2px solid var(--color-peligro-border);
+}
+
 .diferencia.cuadra {
     background: var(--color-exito-bg);
     color: var(--color-exito-text);

--- a/ui.js
+++ b/ui.js
@@ -86,7 +86,7 @@ export function renderResumen(filteredDates) {
                 <td class="text-right">${formatCurrency(sums.salidas)} €</td>
                 <td class="text-right">${formatCurrency(sums.total)} €</td>
                 <td class="text-right">${formatCurrency(sums.cierre)} €</td>
-                <td class="text-right" style="color: ${Math.abs(sums.diff) < 0.01 ? 'var(--color-exito)' : 'var(--color-peligro)'}">${formatCurrency(sums.diff)} €</td>
+                <td class="text-right" style="color: ${Math.abs(sums.diff) < 0.01 ? 'var(--color-exito)' : (sums.diff < 0 ? 'var(--color-peligro)' : 'var(--color-primario)')}">${formatCurrency(sums.diff)} €</td>
             </tr>
         `;
     }).join('');
@@ -105,7 +105,7 @@ export function renderResumen(filteredDates) {
                 <td class="text-right">${formatCurrency(totalSalidas)} €</td>
                 <td class="text-right">${formatCurrency(totalTotal)} €</td>
                 <td class="text-right">${formatCurrency(totalCierre)} €</td>
-                <td class="text-right">${formatCurrency(totalDiff)} €</td>
+                <td class="text-right" style="color: ${Math.abs(totalDiff) < 0.01 ? 'var(--color-exito)' : (totalDiff < 0 ? 'var(--color-peligro)' : 'var(--color-primario)')}">${formatCurrency(totalDiff)} €</td>
             </tr>`;
     }
 }
@@ -155,7 +155,7 @@ export function renderHistorial(filteredDates) {
                 <td class="text-right">${formatCurrency(totals.salidas)} €</td>
                 <td class="text-right">${formatCurrency(totals.total)} €</td>
                 <td class="text-right">${formatCurrency(data.cierre)} €</td>
-                <td class="text-right" style="color: ${Math.abs(totals.diff) < 0.01 ? 'var(--color-exito)' : 'var(--color-peligro)'}">${formatCurrency(totals.diff)} €</td>
+                <td class="text-right" style="color: ${Math.abs(totals.diff) < 0.01 ? 'var(--color-exito)' : (totals.diff < 0 ? 'var(--color-peligro)' : 'var(--color-primario)')}">${formatCurrency(totals.diff)} €</td>
                 <td class="text-center">
                     <div class="actions-dropdown">
                         <button class="btn btn-secondary btn-small" onclick="toggleActionsMenu('actions-${safeId}')">⋮</button>

--- a/utils/computeTotals.js
+++ b/utils/computeTotals.js
@@ -22,7 +22,7 @@ export function computeTotals(apertura, ingresos, movimientos, cierre) {
     }
 
     const total = aperturaNum + ingresosNum + entradas - salidas;
-    const diff = total - cierreNum;
+    const diff = cierreNum - total;
 
     return {
         entradas,


### PR DESCRIPTION
## Summary
- Display cash differences as negative when the register is short and positive when there is surplus.
- Color daily and total summaries: red for negative, blue for positive, green when balanced.
- Add styles for new difference states and update unit tests.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a232dc92e88329a10749f9e5701f12