### PR TITLE
feat: export and email billing summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,10 @@
                 <!-- Resumen de Facturación -->
                 <div class="summary-section">
                     <h3>📊 Resumen de Facturación</h3>
+                    <div class="actions-row" style="margin-bottom: 10px;">
+                        <button class="btn btn-secondary btn-small" onclick="emailResumen()">Enviar por email</button>
+                        <button class="btn btn-secondary btn-small" onclick="downloadResumenCSV()">Descargar CSV</button>
+                    </div>
                     <div class="table-container">
                         <table>
                             <thead>


### PR DESCRIPTION
## Summary
- allow downloading billing summary in CSV
- enable emailing billing summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23534833c8329abfb7ace3063afd8