### PR TITLE
feat: add email alert endpoint

### DIFF
--- a/api/send-alert.js
+++ b/api/send-alert.js
@@ -1,0 +1,68 @@
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+  host: process.env.EMAIL_HOST,
+  port: Number(process.env.EMAIL_PORT),
+  secure: process.env.EMAIL_SECURE === 'true',
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+  },
+});
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ success: false, error: 'Method not allowed' }));
+    return;
+  }
+
+  if (req.headers?.authorization !== process.env.API_KEY) {
+    res.statusCode = 401;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ success: false, error: 'Unauthorized' }));
+    return;
+  }
+
+  let body;
+  try {
+    body = req.body;
+    if (typeof body === 'string') {
+      body = JSON.parse(body);
+    }
+    if (!body) {
+      const chunks = [];
+      for await (const chunk of req) {
+        chunks.push(chunk);
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString());
+    }
+  } catch {
+    res.statusCode = 400;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ success: false, error: 'Invalid JSON' }));
+    return;
+  }
+
+  const { sucursal, fecha, diferencia, detalle } = body || {};
+
+  const text = `Sucursal: ${sucursal}\nFecha: ${fecha}\nDiferencia: ${diferencia}\nDetalle:\n${detalle}`;
+
+  try {
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: process.env.EMAIL_TO,
+      subject: `Alerta de cierre - ${sucursal} - ${fecha}`,
+      text,
+    });
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ success: true }));
+  } catch (err) {
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ success: false, error: err.message }));
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "nodemailer": "^6.9.4"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add nodemailer dependency
- implement send-alert API to email differences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23ca0a5b883298f115eb440cee2a9