### PR TITLE
feat: include branch info and auth in alert sends

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -8,6 +8,8 @@ const PRECACHE_URLS = [
   './icon-180.png'
 ];
 
+const API_KEY = globalThis.API_KEY || '';
+
 self.addEventListener('install', event => {
   self.skipWaiting();
   event.waitUntil(
@@ -62,8 +64,15 @@ self.addEventListener('sync', event => {
         alertQueue.map(data =>
           fetch('/api/send-alert', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': API_KEY
+            },
             body: JSON.stringify(data)
+          }).then(response => {
+            if (!response.ok) {
+              throw new Error('Failed');
+            }
           })
         )
       ).then(() => {


### PR DESCRIPTION
## Summary
- Extend alert payload with sucursal, diferencia and detalle
- Add Authorization header using API key and surface errors to users
- Apply same auth and response checks in service worker background sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23ef59ad88329b8602e0b7906edaf