### PR TITLE
Handle send-alert HTTP errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,19 +148,27 @@ function recalc() {
             headers: {
                 'Content-Type': 'application/json'
             }
-        }).catch(() => {
-            if ('serviceWorker' in navigator) {
-                navigator.serviceWorker.ready.then(registration => {
-                    if (registration.sync) {
-                        registration.sync.register('send-alert');
-                        navigator.serviceWorker.controller?.postMessage({
-                            type: 'queue-alert',
-                            payload: alertData
-                        });
-                    }
-                });
+        }).then(response => {
+            if (!response.ok) {
+                throw new Error(response.status.toString());
             }
-            showAlert('Alerta enviada en segundo plano', 'info');
+        }).catch(error => {
+            if (error.message === 'Failed to fetch') {
+                if ('serviceWorker' in navigator) {
+                    navigator.serviceWorker.ready.then(registration => {
+                        if (registration.sync) {
+                            registration.sync.register('send-alert');
+                            navigator.serviceWorker.controller?.postMessage({
+                                type: 'queue-alert',
+                                payload: alertData
+                            });
+                        }
+                    });
+                }
+                showAlert('Alerta enviada en segundo plano', 'info');
+            } else {
+                showAlert(`No se pudo enviar la alerta (${error.message})`, 'danger');
+            }
         });
     }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -64,10 +64,16 @@ self.addEventListener('sync', event => {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
+          }).then(response => {
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status}`);
+            }
           })
         )
       ).then(() => {
         alertQueue = [];
+      }).catch(err => {
+        console.error('Error al reenviar alertas', err);
       })
     );
   }


### PR DESCRIPTION
## Summary
- Validate `/api/send-alert` responses and surface HTTP status codes to users
- Ensure service worker re-sends alerts only on successful responses and logs failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23ef752048329b6f34f2ef53efad1