### PR TITLE
Handle send-alert HTTP status and smarter retry

### DIFF
--- a/app.js
+++ b/app.js
@@ -155,8 +155,10 @@ function recalc() {
             }
         })
             .then(response => {
-                if (!response.ok) {
-                    showAlert('No se pudo enviar la alerta', 'danger');
+                if (response.ok) {
+                    showAlert(`Alerta enviada (${response.status})`, 'success');
+                } else {
+                    showAlert(`No se pudo enviar la alerta (${response.status})`, 'danger');
                 }
             })
             .catch(() => {


### PR DESCRIPTION
## Summary
- show HTTP status codes when sending alerts
- retry queued alerts individually and log failures in service worker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a240cbf3e08329b7a1b212944d8b1f