### PR TITLE
Fix summary not updating after deleting last closure

### DIFF
--- a/__tests__/renderResumen.test.js
+++ b/__tests__/renderResumen.test.js
@@ -1,0 +1,44 @@
+import { describe, beforeEach, test, expect } from '@jest/globals';
+import { renderHistorial } from '../ui.js';
+
+// This test ensures that deleting the last saved day updates the billing summary
+// by calling renderResumen even when there are no entries left.
+describe('renderResumen on empty historial', () => {
+    let historialTable;
+    let resumenTable;
+    let resumenTotals;
+
+    beforeEach(() => {
+        historialTable = { innerHTML: '' };
+        resumenTable = { innerHTML: 'prev' };
+        resumenTotals = { innerHTML: 'prevTotals' };
+
+        global.document = {
+            getElementById: (id) => {
+                switch (id) {
+                    case 'historialTable':
+                        return historialTable;
+                    case 'resumenTable':
+                        return resumenTable;
+                    case 'resumenTotals':
+                        return resumenTotals;
+                    default:
+                        return null;
+                }
+            },
+        };
+
+        global.localStorage = {
+            getItem: () => null,
+            setItem: () => {},
+            removeItem: () => {},
+        };
+    });
+
+    test('summary reflects empty data', () => {
+        renderHistorial();
+        expect(resumenTable.innerHTML).toContain('No hay datos');
+        expect(resumenTotals.innerHTML).toBe('');
+    });
+});
+

--- a/ui.js
+++ b/ui.js
@@ -123,6 +123,7 @@ export function renderHistorial(filteredDates) {
 
     if (!dates.length) {
         tbody.innerHTML = '<tr><td colspan="11" class="text-center">No hay datos para mostrar</td></tr>';
+        renderResumen(filteredDates);
         return;
     }
 


### PR DESCRIPTION
## Summary
- Refresh billing summary when all saved closures for a day are removed
- Add regression test ensuring summary clears when no data exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2424978fc8329a5c88cbbf1326e36