### PR TITLE
Mostrar ingresos de tarjeta en historial

### DIFF
--- a/__tests__/renderHistorial.test.js
+++ b/__tests__/renderHistorial.test.js
@@ -1,0 +1,57 @@
+import { describe, beforeEach, test, expect } from '@jest/globals';
+import { renderHistorial } from '../ui.js';
+
+// Ensure card and datáfono incomes are shown in historial
+
+describe('renderHistorial card totals', () => {
+    let historialTable;
+    let resumenTable;
+    let resumenTotals;
+    let store;
+
+    beforeEach(() => {
+        store = {};
+        global.localStorage = {
+            getItem: (key) => store[key] || null,
+            setItem: (key, value) => { store[key] = value; },
+            removeItem: (key) => { delete store[key]; }
+        };
+        // Set up index and a day with card data
+        store['caja:index'] = JSON.stringify(['2024-01-01#1']);
+        store['caja:2024-01-01#1'] = JSON.stringify({
+            fecha: '2024-01-01',
+            sucursal: 'Test',
+            apertura: 0,
+            ingresos: 0,
+            ingresosTarjetaExora: 100,
+            ingresosTarjetaDatafono: 80,
+            movimientos: [],
+            cierre: 0
+        });
+        historialTable = { innerHTML: '' };
+        resumenTable = { innerHTML: '' };
+        resumenTotals = { innerHTML: '' };
+        global.document = {
+            getElementById: (id) => {
+                switch (id) {
+                    case 'historialTable':
+                        return historialTable;
+                    case 'resumenTable':
+                        return resumenTable;
+                    case 'resumenTotals':
+                        return resumenTotals;
+                    default:
+                        return null;
+                }
+            }
+        };
+    });
+
+    test('shows card incomes and difference', () => {
+        renderHistorial();
+        expect(historialTable.innerHTML).toContain('100,00 €');
+        expect(historialTable.innerHTML).toContain('80,00 €');
+        expect(historialTable.innerHTML).toContain('20,00 €');
+    });
+});
+

--- a/app.js
+++ b/app.js
@@ -500,10 +500,12 @@ function downloadDayCSV(date) {
     }
 
     const totals = computeTotals(dayData.apertura, dayData.ingresos, dayData.movimientos, dayData.cierre);
+    const diferenciaTarjeta = (dayData.ingresosTarjetaExora || 0) - (dayData.ingresosTarjetaDatafono || 0);
     const cajaHeaders = [
         'Fecha', 'Hora', 'Sucursal', 'Apertura de caja (€)', 'Responsable apertura de caja',
-        'Ingresos en efectivo (€)', 'Gestión de tesorería (salidas)', 'Gestión de tesorería (entradas)',
-        'Total en caja', 'Cierre de caja', 'Diferencia', 'Responsable de cierre de caja'
+        'Ingresos en efectivo (€)', 'Ingresos tarjeta (Exora)', 'Ingresos tarjeta (Datáfono)', 'Diferencia tarjeta (€)',
+        'Gestión de tesorería (salidas)', 'Gestión de tesorería (entradas)',
+        'Total en caja', 'Cierre de caja', 'Diferencia efectivo', 'Responsable de cierre de caja'
     ];
     const cajaData = [[
         formatDate(date.split('#')[0]),
@@ -512,6 +514,9 @@ function downloadDayCSV(date) {
         dayData.apertura,
         dayData.responsableApertura,
         dayData.ingresos,
+        dayData.ingresosTarjetaExora || 0,
+        dayData.ingresosTarjetaDatafono || 0,
+        diferenciaTarjeta,
         totals.salidas,
         totals.entradas,
         totals.total,

--- a/index.html
+++ b/index.html
@@ -195,6 +195,9 @@
                                 <th>Sucursal</th>
                                 <th class="text-right">Apertura</th>
                                 <th class="text-right">Ingresos</th>
+                                <th class="text-right">Tarjeta Exora</th>
+                                <th class="text-right">Tarjeta Datáfono</th>
+                                <th class="text-right">Dif. Tarjeta</th>
                                 <th class="text-right">Entradas</th>
                                 <th class="text-right">Salidas</th>
                                 <th class="text-right">Total</th>

--- a/ui.js
+++ b/ui.js
@@ -141,6 +141,9 @@ export function renderHistorial(filteredDates) {
         if (!data) return '';
         const [day, turno] = date.split('#');
         const totals = computeTotals(data.apertura, data.ingresos, data.movimientos, data.cierre);
+        const tarjetaExora = parseNum(data.ingresosTarjetaExora || 0);
+        const tarjetaDatafono = parseNum(data.ingresosTarjetaDatafono || 0);
+        const diffTarjeta = tarjetaExora - tarjetaDatafono;
 
         const hora = data.horaGuardado ? new Date(data.horaGuardado).toLocaleTimeString('es-ES') : '';
         const safeId = date.replace(/[^a-z0-9]/gi, '_');
@@ -152,6 +155,9 @@ export function renderHistorial(filteredDates) {
                 <td>${data.sucursal}</td>
                 <td class="text-right">${formatCurrency(data.apertura)} €</td>
                 <td class="text-right">${formatCurrency(data.ingresos)} €</td>
+                <td class="text-right">${formatCurrency(tarjetaExora)} €</td>
+                <td class="text-right">${formatCurrency(tarjetaDatafono)} €</td>
+                <td class="text-right" style="color: ${Math.abs(diffTarjeta) < 0.01 ? 'var(--color-exito)' : (diffTarjeta < 0 ? 'var(--color-peligro)' : 'var(--color-primario)')}">${formatCurrency(diffTarjeta)} €</td>
                 <td class="text-right">${formatCurrency(totals.entradas)} €</td>
                 <td class="text-right">${formatCurrency(totals.salidas)} €</td>
                 <td class="text-right">${formatCurrency(totals.total)} €</td>


### PR DESCRIPTION
## Summary
- Add card and dataphone income columns with their difference in history table
- Render saved card values and difference in history rows and CSV export
- Cover rendering logic with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a31a5b9f808329a90f1ed995bd330d