### PR TITLE
Limpiar importe al enfocar si es cero

### DIFF
--- a/app.js
+++ b/app.js
@@ -874,7 +874,14 @@ document.addEventListener('DOMContentLoaded', function() {
             addMovimiento();
         }
     });
-    
+
+    // Limpiar importe si es 0 al enfocar
+    document.getElementById('importeMovimiento').addEventListener('focus', function() {
+        if (parseNum(this.value) === 0) {
+            this.value = '';
+        }
+    });
+
     // Formatear campos de moneda al perder el foco
     document.getElementById('importeMovimiento').addEventListener('blur', function() {
         if (this.value) {


### PR DESCRIPTION
## Summary
- Vacía automáticamente el campo de importe al recibir foco cuando su valor es 0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3343807d88329b6455e00af567d25