### PR TITLE
fix: preserve ISO date when saving records

### DIFF
--- a/app.js
+++ b/app.js
@@ -298,8 +298,16 @@ async function saveDay() {
         // Enviar registro al backend para guardarlo en Google Sheets
         const totals = computeTotals(apertura, ingresos, currentMovimientos, cierre);
         const payload = {
-            fecha: formatDate(fecha),
-            hora: new Date().toLocaleTimeString('es-ES'),
+            // Mantener la fecha en formato ISO (YYYY-MM-DD) evita
+            // que Google Sheets interprete el valor como una fórmula
+            // o como una fecha en otro formato regional.
+            fecha,
+            // Se envía la hora con precisión de minutos para que sea
+            // más consistente con las anotaciones realizadas manualmente.
+            hora: new Date().toLocaleTimeString('es-ES', {
+                hour: '2-digit',
+                minute: '2-digit'
+            }),
             sucursal,
             apertura,
             ingresos,


### PR DESCRIPTION
## Summary
- avoid locale formatting when sending date to append-record endpoint
- send time with minute precision to align with manual annotations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3b2fd245c8329879a185be160c558