### PR TITLE
Sync deletions with Google Sheets

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -140,6 +140,10 @@ describe('saveDay', () => {
         global.localStorage.setItem.mockImplementation((k, v) => { store[k] = v; });
         global.localStorage.getItem.mockImplementation((k) => store[k] || null);
         global.localStorage.removeItem.mockImplementation((k) => { delete store[k]; });
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ id: 'test-id' })
+        }));
         elements = {
             fecha: { value: '2025-01-01' },
             apertura: { value: '0' },

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,4 +1,4 @@
-import { describe, beforeEach, test, expect } from '@jest/globals';
+import { describe, beforeEach, test, expect, jest } from '@jest/globals';
 import { saveDayData, loadDay, getDayIndex, deleteDay } from '../storage.js';
 
 let store = {};
@@ -10,6 +10,7 @@ beforeEach(() => {
     getItem: (k) => store[k] || null,
     removeItem: (k) => { delete store[k]; }
   };
+  global.fetch = undefined;
 });
 
 describe('saveDayData with multiple closings per day', () => {
@@ -35,6 +36,19 @@ describe('saveDayData with multiple closings per day', () => {
     deleteDay(key);
     expect(getDayIndex()).toHaveLength(0);
     expect(loadDay(key)).toBeNull();
+  });
+
+  test('deleteDay calls API when sheetId exists', () => {
+    global.fetch = jest.fn(() => Promise.resolve({}));
+    const key = saveDayData('2024-01-01', { cierre: 100, sheetId: 'abc' });
+    deleteDay(key);
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/delete-record',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ id: 'abc' })
+      })
+    );
   });
 });
 

--- a/storage.js
+++ b/storage.js
@@ -56,6 +56,19 @@ export function saveDayData(date, data, existingKey = null) {
 }
 
 export function deleteDay(date) {
+    const data = loadDay(date);
     localStorage.removeItem(`caja:${date}`);
     updateDayIndex(date, 'remove');
+
+    if (data?.sheetId && typeof fetch !== 'undefined') {
+        try {
+            fetch('/api/delete-record', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id: data.sheetId })
+            });
+        } catch (err) {
+            console.error('No se pudo borrar en Sheets', err);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Track and persist Google Sheets record IDs when saving days, updating existing rows instead of always appending.
- Remove records from the sheet when deleted in the web app and add unit coverage for the API call.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3b54a9ce483298b593f40844f81a8