### PR TITLE
Fix horizontal overflow on iPad

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,7 @@ body {
     line-height: 1.5;
     color: #333;
     background-color: var(--color-claro);
+    overflow-x: hidden;
 }
 
 .visually-hidden {
@@ -58,7 +59,7 @@ body {
 
 .header {
     text-align: center;
-    margin: 0 -20px 30px;
+    margin: 0 0 30px;
     padding: 20px;
     background: linear-gradient(135deg, var(--color-primario) 0%, var(--color-secundario) 100%);
     color: white;


### PR DESCRIPTION
## Summary
- avoid horizontal scrolling by hiding overflow and removing negative margins from header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a9d886288329b0f979f9823e4608