### PR TITLE
Adjust layout for iPad 10th gen width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -93,7 +93,7 @@ body {
     gap: 30px;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 820px) {
     .main-content {
         grid-template-columns: 1fr 1fr;
     }
@@ -494,7 +494,7 @@ tr:hover {
     color: var(--color-peligro-text);
 }
 
-@media (max-width: 1023px) {
+@media (max-width: 819px) {
     .container {
         padding: 15px;
     }


### PR DESCRIPTION
## Summary
- Adjust CSS breakpoints to support two-column layout at iPad 10th gen width.
- Tweak mobile breakpoint to exclude iPad 10th gen from single-column rules.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ac1b41948329bf16ad23ecaf8445