### PR TITLE
Fetch raw numeric values from Google Sheets

### DIFF
--- a/api/list-records.js
+++ b/api/list-records.js
@@ -32,6 +32,7 @@ export default async function handler(req, res) {
     const response = await sheets.spreadsheets.values.get({
       spreadsheetId,
       range,
+      valueRenderOption: 'UNFORMATTED_VALUE',
     });
     const rows = response.data.values || [];
 


### PR DESCRIPTION
## Summary
- Request unformatted values from Google Sheets so numeric fields are parsed correctly when listing records

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a632a7322c8329ab50c85ca51c249e