### PR TITLE
Permitir scroll independiente en columnas de registro e historial

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,10 @@
     --color-primario-rgb: 88, 101, 242;
 }
 
+html, body {
+    height: 100%;
+}
+
 body {
     font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 16px;
@@ -94,8 +98,25 @@ body {
 }
 
 @media (min-width: 820px) {
+    body {
+        overflow: hidden;
+    }
+
+    .container {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
     .main-content {
+        flex: 1;
         grid-template-columns: 1fr 1fr;
+        overflow: hidden;
+    }
+
+    .panel {
+        overflow-y: auto;
+        min-height: 0;
     }
 }
 


### PR DESCRIPTION
## Resumen
- Ajuste de estilos para habilitar scroll independiente en el registro diario y el historial.
- Contenedor principal a altura completa y paneles con overflow propio en escritorios.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6470a93d88329af2b638e22ee7eb8