### PR TITLE
Ajustar tamaños de panel para evitar scroll horizontal en iPad

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -110,7 +110,7 @@ body {
 
     .main-content {
         flex: 1;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: 260px 1fr;
         overflow: hidden;
     }
 
@@ -421,7 +421,7 @@ table {
 
 @media (min-width: 820px) {
     table {
-        min-width: 800px;
+        min-width: 650px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Hacer que el panel de registro tenga un ancho fijo y el historial utilice el espacio restante
- Reducir ancho mínimo de la tabla de historial para que quepa sin desplazamiento horizontal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a64dddc6988329aa4c8ac6ad174c9e