### PR TITLE
fix: lock panel horizontal panning on iPad

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -126,6 +126,7 @@ body {
     padding: 25px;
     box-shadow: 0 4px 20px rgba(0,0,0,0.08);
     overflow-x: hidden;
+    touch-action: pan-y;
 }
 
 .panel h2 {


### PR DESCRIPTION
## Summary
- prevent horizontal pan on scrollable panels to keep columns fixed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6532110888329bbbb4a5b696b6c07