### PR TITLE
Ajustar color de texto en inputs de fecha para iOS

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -169,6 +169,16 @@ input:focus, select:focus, textarea:focus {
     box-shadow: 0 0 0 3px rgba(var(--color-primario-rgb),0.1);
 }
 
+/* Improve date input visibility on iOS devices */
+input[type="date"]::-webkit-datetime-edit {
+    color: white;
+}
+
+input[type="date"]:focus::-webkit-datetime-edit,
+input[type="date"]:valid::-webkit-datetime-edit {
+    color: black;
+}
+
 .inline-inputs {
     display: grid;
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary
- Asegura que el texto de los campos de fecha se muestre en blanco por defecto en iOS y cambie a negro cuando el campo recibe foco o tiene un valor, mejorando la visibilidad en iPad.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6575ac1f08329bd258e5033b3d9b2