### PR TITLE
feat: apply today filter by default

### DIFF
--- a/app.js
+++ b/app.js
@@ -973,7 +973,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Inicializar UI
     loadDraft();
     renderMovimientos(currentMovimientos);
-    renderHistorial(filteredDates);
+    filterToday();
     recalc();
     
     console.log('📊 Sistema de Caja LBJ inicializado correctamente');


### PR DESCRIPTION
## Summary
- apply `filterToday` on startup so the date selector defaults to today's range

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65a8075f0832983f61d0d2b8128bd