### PR TITLE
Refactor API endpoints to use shared Google Sheets client

### DIFF
--- a/api/append-record.js
+++ b/api/append-record.js
@@ -1,65 +1,15 @@
 // api/append-record.js
-import { google } from 'googleapis';
-
-function uuid() {
-  // UUID v4 simple (suficiente para hoja de cálculo)
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-    const r = (Math.random() * 16) | 0, v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
+import { appendRecord } from './googleSheets.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
-    res.status(405).json({ error: 'Solo se permite POST' }); return;
+    res.status(405).json({ error: 'Solo se permite POST' });
+    return;
   }
 
   try {
-    const raw = process.env.GSHEET_CREDENTIALS;
-    if (!raw) { res.status(500).json({ error: 'Falta GSHEET_CREDENTIALS' }); return; }
-    const creds = JSON.parse(raw);
-
-    const auth = new google.auth.JWT(
-      creds.client_email, null, creds.private_key,
-      ['https://www.googleapis.com/auth/spreadsheets']
-    );
-    const sheets = google.sheets({ version: 'v4', auth });
-
-    const spreadsheetId = process.env.GSHEET_ID;                 // <- tu env correcta
-    const sheetName = process.env.GSHEET_NAME || 'LBJ';
-    const range = `${sheetName}!A1`;
-
-    // Genera ID si no viene
-    const id = req.body.id || uuid();
-
-    // Orden de columnas en tu hoja:
-    // ID | Fecha | Hora | Sucursal | Apertura | Ingresos | Tarjeta Exora | Tarjeta Datafono | Dif | Entradas | Salidas | Total | Cierre | Dif
-    const values = [[
-      id,
-      req.body.fecha,
-      req.body.hora,
-      req.body.sucursal,
-      req.body.apertura,
-      req.body.ingresos,
-      req.body.tarjetaExora,
-      req.body.tarjetaDatafono,
-      req.body.dif,
-      req.body.entradas,
-      req.body.salidas,
-      req.body.total,
-      req.body.cierre,
-      req.body.dif
-    ]];
-
-    await sheets.spreadsheets.values.append({
-      spreadsheetId,
-      range,
-      valueInputOption: 'USER_ENTERED',
-      insertDataOption: 'INSERT_ROWS',
-      requestBody: { values }
-    });
-
-    res.status(200).json({ ok: true, id, mensaje: `Cierre guardado en hoja ${sheetName}` });
+    const id = await appendRecord(req.body || {});
+    res.status(200).json({ ok: true, id, mensaje: 'Cierre guardado en hoja' });
   } catch (err) {
     console.error('Error Google Sheets:', err);
     res.status(500).json({ error: 'No se pudo guardar', detalle: String(err) });

--- a/api/delete-record.js
+++ b/api/delete-record.js
@@ -1,67 +1,21 @@
-// api/delete-record.js  (ESM)
-import { google } from 'googleapis';
+// api/delete-record.js
+import { deleteRecord } from './googleSheets.js';
 
 export default async function handler(req, res) {
-  if (req.method !== 'POST') { res.status(405).json({ error: 'Solo POST' }); return; }
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Solo POST' });
+    return;
+  }
+
+  const id = req.body?.id;
+  if (!id) {
+    res.status(400).json({ error: 'Falta id' });
+    return;
+  }
 
   try {
-    const raw = process.env.GSHEET_CREDENTIALS;
-    if (!raw) { res.status(500).json({ error: 'Falta GSHEET_CREDENTIALS' }); return; }
-    const creds = JSON.parse(raw);
-
-    const auth = new google.auth.JWT(
-      creds.client_email, null, creds.private_key,
-      ['https://www.googleapis.com/auth/spreadsheets']
-    );
-    const sheets = google.sheets({ version: 'v4', auth });
-
-    const spreadsheetId = process.env.GSHEET_ID;
-    const sheetName = process.env.GSHEET_NAME || 'LBJ';
-
-    // 1) ID obligatorio
-    const id = req.body?.id;
-    if (!id) { res.status(400).json({ error: 'Falta id' }); return; }
-
-    // 2) Buscar la fila por ID (columna A)
-    const colA = await sheets.spreadsheets.values.get({
-      spreadsheetId,
-      range: `${sheetName}!A:A`,
-      majorDimension: 'ROWS'
-    });
-    const rows = colA.data.values || [];
-    let rowNumber = -1;
-    for (let i = 1; i < rows.length; i++) { // i=1 salta cabecera
-      if (rows[i] && rows[i][0] === id) { rowNumber = i + 1; break; } // Sheets es 1-based
-    }
-    if (rowNumber === -1) { res.status(404).json({ error: 'ID no encontrado' }); return; }
-
-    // 3) Obtener sheetId numérico (gid) para poder borrar la fila real
-    const meta = await sheets.spreadsheets.get({ spreadsheetId });
-    const tab = meta.data.sheets.find(s => s.properties.title === sheetName);
-    if (!tab) { res.status(404).json({ error: `Hoja ${sheetName} no encontrada` }); return; }
-    const sheetId = tab.properties.sheetId;
-
-    // 4) Borrar la fila (deleteDimension usa índices 0-based y endIndex exclusivo)
-    const startIndex = rowNumber - 1; // convertir a 0-based
-    const endIndex = rowNumber;
-
-    await sheets.spreadsheets.batchUpdate({
-      spreadsheetId,
-      requestBody: {
-        requests: [{
-          deleteDimension: {
-            range: {
-              sheetId,
-              dimension: 'ROWS',
-              startIndex,
-              endIndex
-            }
-          }
-        }]
-      }
-    });
-
-    res.status(200).json({ ok: true, id, mensaje: `Registro ${id} borrado (fila ${rowNumber})` });
+    await deleteRecord(id);
+    res.status(200).json({ ok: true, id, mensaje: `Registro ${id} borrado` });
   } catch (err) {
     console.error('Delete error:', err);
     res.status(500).json({ error: 'No se pudo borrar', detalle: String(err) });

--- a/api/update-record.js
+++ b/api/update-record.js
@@ -1,71 +1,21 @@
-// api/update-record.js  (ESM)
-import { google } from 'googleapis';
+// api/update-record.js
+import { updateRecord } from './googleSheets.js';
 
 export default async function handler(req, res) {
-  if (req.method !== 'POST') { res.status(405).json({ error: 'Solo POST' }); return; }
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Solo POST' });
+    return;
+  }
+
+  const id = req.body?.id;
+  if (!id) {
+    res.status(400).json({ error: 'Falta id' });
+    return;
+  }
 
   try {
-    const raw = process.env.GSHEET_CREDENTIALS;
-    if (!raw) { res.status(500).json({ error: 'Falta GSHEET_CREDENTIALS' }); return; }
-    const creds = JSON.parse(raw);
-
-    const auth = new google.auth.JWT(
-      creds.client_email, null, creds.private_key,
-      ['https://www.googleapis.com/auth/spreadsheets']
-    );
-    const sheets = google.sheets({ version: 'v4', auth });
-
-    const spreadsheetId = process.env.GSHEET_ID;
-    const sheetName = process.env.GSHEET_NAME || 'LBJ';
-
-    // 1) Necesitamos al menos el ID
-    const id = req.body?.id;
-    if (!id) { res.status(400).json({ error: 'Falta id' }); return; }
-
-    // 2) Buscar la fila por ID (columna A)
-    const colA = await sheets.spreadsheets.values.get({
-      spreadsheetId,
-      range: `${sheetName}!A:A`,
-      majorDimension: 'ROWS'
-    });
-    const rows = colA.data.values || [];
-    // encontrar el índice: fila 1 es cabecera → datos comienzan en índice 1
-    let rowNumber = -1;
-    for (let i = 1; i < rows.length; i++) {
-      if (rows[i] && rows[i][0] === id) { rowNumber = i + 1; break; } // +1 porque Sheets es 1-based
-    }
-    if (rowNumber === -1) { res.status(404).json({ error: 'ID no encontrado' }); return; }
-
-    // 3) Preparar los valores en el mismo orden de columnas:
-    // A:ID | B:Fecha | C:Hora | D:Sucursal | E:Apertura | F:Ingresos | G:Tarjeta Exora | H:Tarjeta Datafono |
-    // I:Dif | J:Entradas | K:Salidas | L:Total | M:Cierre | N:Dif
-    const values = [[
-      id,
-      req.body.fecha ?? '',
-      req.body.hora ?? '',
-      req.body.sucursal ?? '',
-      req.body.apertura ?? '',
-      req.body.ingresos ?? '',
-      req.body.tarjetaExora ?? '',
-      req.body.tarjetaDatafono ?? '',
-      req.body.dif ?? '',
-      req.body.entradas ?? '',
-      req.body.salidas ?? '',
-      req.body.total ?? '',
-      req.body.cierre ?? '',
-      req.body.dif ?? ''
-    ]];
-
-    // 4) Actualizar exactamente esa fila (A..N)
-    const range = `${sheetName}!A${rowNumber}:N${rowNumber}`;
-    await sheets.spreadsheets.values.update({
-      spreadsheetId,
-      range,
-      valueInputOption: 'USER_ENTERED',
-      requestBody: { values }
-    });
-
-    res.status(200).json({ ok: true, id, mensaje: `Registro ${id} actualizado en fila ${rowNumber}` });
+    await updateRecord(id, req.body || {});
+    res.status(200).json({ ok: true, id, mensaje: `Registro ${id} actualizado` });
   } catch (err) {
     console.error('Update error:', err);
     res.status(500).json({ error: 'No se pudo actualizar', detalle: String(err) });


### PR DESCRIPTION
## Summary
- Simplify append, update, and delete endpoints by using common googleSheets helper
- Remove duplicated authentication and Sheets logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65e37b60083298312345f707ba0c4