### PR TITLE
Fix deletion of Google Sheets records

### DIFF
--- a/app.js
+++ b/app.js
@@ -414,11 +414,33 @@ function deleteCurrentDay() {
     }
 }
 
-function deleteDayFromHistorial(fecha) {
+function deleteDayFromHistorial(id, fecha) {
+    const index = getDayIndex();
+    let key = id;
+
+    if (!index.includes(id)) {
+        key = index.find(k => {
+            const data = loadDay(k);
+            return data?.sheetId === id;
+        }) || null;
+    }
+
     if (confirm(`¿Estás seguro de que quieres borrar el día ${formatDate(fecha)}?`)) {
-        deleteDay(fecha);
-        if (currentEditKey === fecha) {
-            clearForm();
+        if (key) {
+            deleteDay(key);
+            if (currentEditKey === key) {
+                clearForm();
+            }
+        } else {
+            try {
+                fetch('/api/delete-record', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ id })
+                });
+            } catch (err) {
+                console.error('No se pudo borrar en Sheets', err);
+            }
         }
 
         renderHistorial(filteredDates);

--- a/ui.js
+++ b/ui.js
@@ -227,7 +227,7 @@ export async function renderHistorial(filteredDates) {
                             <button onclick="closeAllActionsMenus(); editDay('${r.id}')">Editar</button>
                             <button onclick="closeAllActionsMenus(); emailDay('${r.id}')">Enviar por email</button>
                             <button onclick="closeAllActionsMenus(); downloadDayCSV('${r.id}')">Descargar CSV</button>
-                            <button class="delete" onclick="closeAllActionsMenus(); deleteDayFromHistorial('${r.id}')">Eliminar</button>
+                            <button class="delete" onclick="closeAllActionsMenus(); deleteDayFromHistorial('${r.id}', '${r.fecha}')">Eliminar</button>
                         </div>
                     </div>
                 </td>


### PR DESCRIPTION
## Summary
- handle records fetched from Google Sheets when deleting from history
- pass record date separately to ensure confirmation message shows correct day

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a662fe9ccc83298cc3e27a0b96afbc