### PR TITLE
Fix deletion refresh and allow editing saved days

### DIFF
--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -31,24 +31,24 @@ describe('saveDayData with multiple closings per day', () => {
     expect(loadDay(key1).cierre).toBe(150);
   });
 
-  test('deleteDay removes entry and index', () => {
-    const key = saveDayData('2024-01-01', { cierre: 100 });
-    deleteDay(key);
-    expect(getDayIndex()).toHaveLength(0);
-    expect(loadDay(key)).toBeNull();
-  });
+    test('deleteDay removes entry and index', async () => {
+      const key = saveDayData('2024-01-01', { cierre: 100 });
+      await deleteDay(key);
+      expect(getDayIndex()).toHaveLength(0);
+      expect(loadDay(key)).toBeNull();
+    });
 
-  test('deleteDay calls API when sheetId exists', () => {
-    global.fetch = jest.fn(() => Promise.resolve({}));
-    const key = saveDayData('2024-01-01', { cierre: 100, sheetId: 'abc' });
-    deleteDay(key);
-    expect(fetch).toHaveBeenCalledWith(
-      '/api/delete-record',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ id: 'abc' })
-      })
-    );
-  });
+    test('deleteDay calls API when sheetId exists', async () => {
+      global.fetch = jest.fn(() => Promise.resolve({}));
+      const key = saveDayData('2024-01-01', { cierre: 100, sheetId: 'abc' });
+      await deleteDay(key);
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/delete-record',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ id: 'abc' })
+        })
+      );
+    });
 });
 

--- a/app.js
+++ b/app.js
@@ -400,21 +400,21 @@ function newDay() {
     showAlert('Formulario limpiado para nuevo día', 'info');
 }
 
-function deleteCurrentDay() {
+async function deleteCurrentDay() {
     if (!currentEditKey) {
         showAlert('No hay un día cargado para borrar', 'danger');
         return;
     }
 
     if (confirm(`¿Estás seguro de que quieres borrar el día ${formatDate(currentEditKey)}?`)) {
-        deleteDay(currentEditKey);
+        await deleteDay(currentEditKey);
         clearForm();
-        renderHistorial(filteredDates);
+        await renderHistorial(filteredDates);
         showAlert(`Día ${formatDate(currentEditKey)} borrado correctamente`, 'success');
     }
 }
 
-function deleteDayFromHistorial(id, fecha) {
+async function deleteDayFromHistorial(id, fecha) {
     const index = getDayIndex();
     let key = id;
 
@@ -427,13 +427,13 @@ function deleteDayFromHistorial(id, fecha) {
 
     if (confirm(`¿Estás seguro de que quieres borrar el día ${formatDate(fecha)}?`)) {
         if (key) {
-            deleteDay(key);
+            await deleteDay(key);
             if (currentEditKey === key) {
                 clearForm();
             }
         } else {
             try {
-                fetch('/api/delete-record', {
+                await fetch('/api/delete-record', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ id })
@@ -443,17 +443,27 @@ function deleteDayFromHistorial(id, fecha) {
             }
         }
 
-        renderHistorial(filteredDates);
+        await renderHistorial(filteredDates);
         showAlert(`Día ${formatDate(fecha)} borrado correctamente`, 'success');
     }
 }
 
-function editDay(fecha) {
-    const data = loadDay(fecha);
+function editDay(id) {
+    const index = getDayIndex();
+    let key = id;
+
+    if (!index.includes(id)) {
+        key = index.find(k => {
+            const data = loadDay(k);
+            return data?.sheetId === id;
+        }) || null;
+    }
+
+    const data = key ? loadDay(key) : null;
     if (data) {
         loadFormData(data);
-        currentEditKey = fecha;
-        showAlert(`Día ${formatDate(fecha)} cargado para edición`, 'info');
+        currentEditKey = key;
+        showAlert(`Día ${formatDate(key)} cargado para edición`, 'info');
         // Hacer scroll hacia arriba para ver el formulario
         document.querySelector('.header').scrollIntoView({ behavior: 'smooth' });
     } else {

--- a/storage.js
+++ b/storage.js
@@ -55,14 +55,14 @@ export function saveDayData(date, data, existingKey = null) {
     return key;
 }
 
-export function deleteDay(date) {
+export async function deleteDay(date) {
     const data = loadDay(date);
     localStorage.removeItem(`caja:${date}`);
     updateDayIndex(date, 'remove');
 
     if (data?.sheetId && typeof fetch !== 'undefined') {
         try {
-            fetch('/api/delete-record', {
+            await fetch('/api/delete-record', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ id: data.sheetId })


### PR DESCRIPTION
## Summary
- Ensure local deletions await remote API before refreshing the UI
- Map Google Sheets IDs to local keys so records can be edited
- Adjust tests for async `deleteDay`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a66652fffc8329aa50b6f43b264c2a