### PR TITLE
Avoid cached record list after deletion

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -69,7 +69,7 @@ export async function renderResumen(filteredDates, records) {
                     params.push(`sucursal=${encodeURIComponent(sucursal)}`);
                 }
                 if (params.length) url += `?${params.join('&')}`;
-                const res = await fetch(url);
+                const res = await fetch(url, { cache: 'no-store' });
                 if (res.ok) {
                     const json = await res.json();
                     records = json.records || [];
@@ -175,7 +175,7 @@ export async function renderHistorial(filteredDates) {
                 params.push(`sucursal=${encodeURIComponent(sucursal)}`);
             }
             if (params.length) url += `?${params.join('&')}`;
-            const res = await fetch(url);
+            const res = await fetch(url, { cache: 'no-store' });
             if (res.ok) {
                 const json = await res.json();
                 records = json.records || [];


### PR DESCRIPTION
## Summary
- prevent `/api/list-records` responses from being cached in historial and resumen views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a668c7f6d88329b855f7f1f2bac556