### PR TITLE
Disable today filter briefly after record deletions

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,7 @@ if ('serviceWorker' in navigator) {
 let currentMovimientos = [];
 let filteredDates = null;
 let currentEditKey = null;
+let filterRestoreTimeout = null;
 const API_KEY = globalThis.API_KEY || '';
 
 const empleadosPorSucursal = {
@@ -409,7 +410,7 @@ async function deleteCurrentDay() {
     if (confirm(`¿Estás seguro de que quieres borrar el día ${formatDate(currentEditKey)}?`)) {
         await deleteDay(currentEditKey);
         clearForm();
-        await renderHistorial(filteredDates);
+        await temporarilyDisableTodayFilter();
         showAlert(`Día ${formatDate(currentEditKey)} borrado correctamente`, 'success');
     }
 }
@@ -445,7 +446,7 @@ async function deleteDayFromHistorial(id, fecha) {
 
         // Esperar un momento para que la eliminación se refleje en Google Sheets
         await new Promise(resolve => setTimeout(resolve, 1000));
-        await renderHistorial(filteredDates);
+        await temporarilyDisableTodayFilter();
         showAlert(`Día ${formatDate(fecha)} borrado correctamente`, 'success');
     }
 }
@@ -559,6 +560,20 @@ function clearDateFilter() {
     document.getElementById('fechaHasta').value = '';
     renderHistorial(filteredDates);
     showAlert('Filtro de fechas eliminado', 'info');
+}
+
+async function temporarilyDisableTodayFilter() {
+    filteredDates = null;
+    document.getElementById('fechaDesde').value = '';
+    document.getElementById('fechaHasta').value = '';
+    await renderHistorial(filteredDates);
+    if (filterRestoreTimeout) {
+        clearTimeout(filterRestoreTimeout);
+    }
+    filterRestoreTimeout = setTimeout(() => {
+        filterToday();
+        filterRestoreTimeout = null;
+    }, 5000);
 }
 
 // Funciones de exportación
@@ -1184,6 +1199,7 @@ function wireUI() {
             btnBorrar.disabled = true;
             try {
                 await deleteRecord(id);
+                await temporarilyDisableTodayFilter();
             } catch (err) {
                 console.error(err);
             } finally {


### PR DESCRIPTION
## Summary
- Temporarily clear the default "Hoy" date filter after deleting a record
- Automatically restore the filter after 5 seconds
- Apply this behavior when deleting current day, history items, or records via the delete button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a66f188cc4832998e71dbfb38453de