### PR TITLE
Disable default today filter on startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -1007,7 +1007,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Inicializar UI
     loadDraft();
     renderMovimientos(currentMovimientos);
-    filterToday();
+    clearDateFilter();
     recalc();
     
     console.log('📊 Sistema de Caja LBJ inicializado correctamente');


### PR DESCRIPTION
## Summary
- Replace automatic `filterToday` call with `clearDateFilter` so the app loads with no date filter active.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6716181088329b6e39d453e757c88