### PR TITLE
Fix iPad viewport after hiding keyboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,19 @@
 import { parseNum, formatCurrency, formatDate, getTodayString, computeTotals } from "./utils/index.js";
 import { getDayIndex, loadDay, saveDayData, deleteDay, saveToLocalStorage, getFromLocalStorage } from "./storage.js";
 import { renderMovimientos, renderHistorial, showAlert, displayTestResults, hideTests } from "./ui.js";
+
+function updateViewportHeight() {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+}
+
+if (typeof window !== 'undefined' && window.addEventListener) {
+    window.addEventListener('resize', updateViewportHeight);
+    if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', updateViewportHeight);
+    }
+    updateViewportHeight();
+}
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./service-worker.js', { updateViaCache: 'none' }).then(registration => {
         registration.update();

--- a/styles.css
+++ b/styles.css
@@ -28,10 +28,12 @@
     --color-info-text: #0b4b56;
     --color-info-border: #b0d8e3;
     --color-primario-rgb: 88, 101, 242;
+    --vh: 1vh;
 }
 
 html, body {
     height: 100%;
+    min-height: calc(var(--vh, 1vh) * 100);
 }
 
 body {


### PR DESCRIPTION
## Summary
- Adjust app layout to track viewport height and prevent a gray bar after dismissing the iPad keyboard
- Use a CSS variable for dynamic viewport height and update it on resize

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a85aeff6908329b8f416c3e0ebd5a0