### PR TITLE
Fix iPad viewport after hiding keyboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,21 @@
 import { parseNum, formatCurrency, formatDate, getTodayString, computeTotals } from "./utils/index.js";
 import { getDayIndex, loadDay, saveDayData, deleteDay, saveToLocalStorage, getFromLocalStorage } from "./storage.js";
 import { renderMovimientos, renderHistorial, showAlert, displayTestResults, hideTests } from "./ui.js";
+
+function updateViewportHeight() {
+    const height = (window.visualViewport ? window.visualViewport.height : window.innerHeight) * 0.01;
+    document.documentElement.style.setProperty('--vh', `${height}px`);
+}
+
+if (typeof window !== 'undefined' && window.addEventListener) {
+    const refresh = () => requestAnimationFrame(updateViewportHeight);
+    window.addEventListener('resize', refresh);
+    if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', refresh);
+    }
+    document.addEventListener('focusout', () => setTimeout(refresh, 50));
+    refresh();
+}
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./service-worker.js', { updateViaCache: 'none' }).then(registration => {
         registration.update();

--- a/styles.css
+++ b/styles.css
@@ -28,10 +28,11 @@
     --color-info-text: #0b4b56;
     --color-info-border: #b0d8e3;
     --color-primario-rgb: 88, 101, 242;
+    --vh: 1vh;
 }
 
 html, body {
-    height: 100%;
+    height: calc(var(--vh, 1vh) * 100);
 }
 
 body {


### PR DESCRIPTION
## Summary
- Recalculate viewport height using `visualViewport` and refresh on input blur to remove gray bar after dismissing the keyboard on iPad
- Set `html` and `body` height based on dynamic `--vh` variable instead of `100%`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a85aeff6908329b8f416c3e0ebd5a0