### PR TITLE
feat: fetch edit data from sheets

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -230,9 +230,37 @@ describe('editDay', () => {
         showAlert.mockClear();
     });
 
-    test('editDay carga registro usando sheetId numérico', () => {
-        window.editDay('123');
+    test('editDay carga registro usando sheetId numérico', async () => {
+        await window.editDay('123');
         expect(elements.fecha.value).toBe('2025-02-01');
+        expect(showAlert).toHaveBeenCalledWith(expect.stringContaining('cargado'), 'info');
+    });
+
+    test('editDay obtiene registro de Google Sheets si no está en localStorage', async () => {
+        store = {};
+        global.localStorage.setItem.mockImplementation((k, v) => { store[k] = v; });
+        global.localStorage.getItem.mockImplementation((k) => store[k] || null);
+        global.localStorage.removeItem.mockImplementation((k) => { delete store[k]; });
+
+        const record = {
+            id: '999',
+            fecha: '2025-03-10',
+            sucursal: 'Central',
+            apertura: 0,
+            ingresos: 0,
+            tarjetaExora: 0,
+            tarjetaDatafono: 0,
+            cierre: 0
+        };
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ ok: true, records: [record] })
+        }));
+
+        await window.editDay('999');
+
+        expect(global.fetch).toHaveBeenCalledWith('/api/list-records?id=999');
+        expect(elements.fecha.value).toBe('2025-03-10');
         expect(showAlert).toHaveBeenCalledWith(expect.stringContaining('cargado'), 'info');
     });
 });

--- a/api/list-records.js
+++ b/api/list-records.js
@@ -30,6 +30,7 @@ export default async function handler(req, res) {
     const sucursal = req.query.sucursal
       ? String(req.query.sucursal).trim().toLowerCase()
       : '';
+    const id = req.query.id ? String(req.query.id).trim() : '';
 
     const range = `${sheetName}!A:N`;
     const response = await sheets.spreadsheets.values.get({
@@ -42,6 +43,7 @@ export default async function handler(req, res) {
     const records = [];
     for (const row of rows) {
       if (!row.length || row[0] === 'ID') continue;
+      if (id && String(row[0]) !== id) continue;
       const rawDate = row[1];
       if (!rawDate) continue;
       let fecha;

--- a/app.js
+++ b/app.js
@@ -466,7 +466,7 @@ async function deleteDayFromHistorial(id, fecha) {
     }
 }
 
-function editDay(id) {
+async function editDay(id) {
     const index = getDayIndex();
     let key = id;
 
@@ -477,7 +477,34 @@ function editDay(id) {
         }) || null;
     }
 
-    const data = key ? loadDay(key) : null;
+    let data = key ? loadDay(key) : null;
+
+    if (!data) {
+        try {
+            const resp = await fetch(`/api/list-records?id=${id}`);
+            const json = await resp.json().catch(() => ({}));
+            const record = json.records && json.records[0];
+            if (record) {
+                data = {
+                    fecha: record.fecha,
+                    sucursal: record.sucursal,
+                    apertura: record.apertura,
+                    responsableApertura: '',
+                    ingresos: record.ingresos,
+                    ingresosTarjetaExora: record.tarjetaExora,
+                    ingresosTarjetaDatafono: record.tarjetaDatafono,
+                    movimientos: [],
+                    cierre: record.cierre,
+                    responsableCierre: '',
+                    sheetId: record.id
+                };
+                key = saveDayData(record.fecha, data);
+            }
+        } catch (err) {
+            console.error('No se pudo obtener de Sheets', err);
+        }
+    }
+
     if (data) {
         loadFormData(data);
         currentEditKey = key;


### PR DESCRIPTION
## Summary
- allow list-records endpoint to filter by id
- load edit form from Google Sheets when local data missing
- cover remote load with new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8cc497f38832998ee36c0146628ca