### PR TITLE
Avoid unauthorized alert requests without API key

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,8 +163,8 @@ function recalc() {
         }
     }
 
-    // Si falta dinero, intenta enviar una alerta
-    if (totals.diff < 0) {
+    // Si falta dinero, intenta enviar una alerta solo si hay API_KEY
+    if (totals.diff < 0 && API_KEY) {
         const alertData = {
             sucursal: localStorage.getItem('sucursal'),
             fecha: document.getElementById('fecha').value,

--- a/service-worker.js
+++ b/service-worker.js
@@ -68,6 +68,7 @@ self.addEventListener('message', event => {
 self.addEventListener('sync', event => {
   if (event.tag === 'send-alert') {
     event.waitUntil((async () => {
+      if (!API_KEY) return;
       const remaining = [];
       for (const data of alertQueue) {
         try {


### PR DESCRIPTION
## Summary
- only send alert when API key is configured to avoid 401 errors
- skip background alert sync if API key is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8d4df8f20832991895c528929caa5