### PR TITLE
Log treasury movements in dedicated sheet

### DIFF
--- a/api/append-tesoreria.js
+++ b/api/append-tesoreria.js
@@ -1,0 +1,17 @@
+import { appendTesoreriaMovimientos } from './googleSheets.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Solo se permite POST' });
+    return;
+  }
+
+  try {
+    const { cierreId, fecha, movimientos } = req.body || {};
+    await appendTesoreriaMovimientos(cierreId, fecha, Array.isArray(movimientos) ? movimientos : []);
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error('Error Tesorería Sheets:', err);
+    res.status(500).json({ error: 'No se pudieron guardar los movimientos', detalle: String(err) });
+  }
+}

--- a/app.js
+++ b/app.js
@@ -314,6 +314,7 @@ async function saveDay() {
         const existing = loadDay(currentEditKey);
         sheetId = existing?.sheetId;
     }
+    const wasNewRecord = !sheetId;
 
     const dayData = {
         fecha,
@@ -372,6 +373,17 @@ async function saveDay() {
                 sheetId = data.id;
                 dayData.sheetId = sheetId;
                 saveDayData(fecha, dayData, currentEditKey);
+            }
+            if (wasNewRecord && sheetId && currentMovimientos.length) {
+                try {
+                    await fetch('/api/append-tesoreria', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ cierreId: sheetId, fecha, movimientos: currentMovimientos })
+                    });
+                } catch (err) {
+                    console.error('No se pudo guardar movimientos en Tesorería', err);
+                }
             }
         } catch (err) {
             console.error(err);

--- a/docs/google-sheets.md
+++ b/docs/google-sheets.md
@@ -6,6 +6,7 @@ Este módulo permite sincronizar los cierres de caja con la hoja de cálculo de 
 
 1. **Credenciales**: guardar el JSON de la cuenta de servicio en un archivo local y establecer la variable de entorno `GSHEET_CREDENTIALS` con la ruta al archivo.
 2. **Hoja de cálculo**: si se desea usar otro libro u hoja, definir `GSHEET_ID` y `GSHEET_NAME` en las variables de entorno.
+3. **Tesorería**: para registrar movimientos de tesorería en una hoja separada, establecer `GSHEET_TREASURY_NAME` con el nombre de dicha hoja. Esta hoja debe tener las columnas `ID`, `FECHA`, `MOVIMIENTO` (Entrada/Salida), `QUIEN` e `IMPORTE` en ese orden.
 
 ## Uso
 


### PR DESCRIPTION
## Summary
- Use GSHEET_TREASURY_NAME env var for configuring the Tesorería sheet
- Document how to configure treasury sheet name in Google Sheets integration
- Record who performed each treasury movement in the Tesorería sheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e391b47c8329834529931e9b8cd5