### PR TITLE
Include quien in Tesorería rows

### DIFF
--- a/__tests__/googleSheets.test.js
+++ b/__tests__/googleSheets.test.js
@@ -1,0 +1,12 @@
+import { buildTesoreriaRow } from '../api/googleSheets.js';
+
+describe('buildTesoreriaRow', () => {
+  test('includes quien in the row', () => {
+    const row = buildTesoreriaRow('1', '2024-01-01', {
+      tipo: 'entrada',
+      quien: 'Juan',
+      importe: 10,
+    });
+    expect(row).toEqual(['1', '2024-01-01', 'Entrada', 'Juan', 10]);
+  });
+});

--- a/api/googleSheets.js
+++ b/api/googleSheets.js
@@ -133,11 +133,12 @@ export async function updateRecord(id, data) {
   }
 }
 
-function buildTesoreriaRow(id, fecha, mov) {
+export function buildTesoreriaRow(id, fecha, mov) {
   return [
     id,
     fecha || '',
     mov.tipo === 'entrada' ? 'Entrada' : 'Salida',
+    mov.quien || '',
     mov.importe || 0,
   ];
 }
@@ -150,7 +151,7 @@ export async function appendTesoreriaMovimientos(cierreId, fecha, movimientos = 
   );
   await client.spreadsheets.values.append({
     spreadsheetId: SHEET_ID,
-    range: `${TESORERIA_SHEET_NAME}!A:D`,
+    range: `${TESORERIA_SHEET_NAME}!A:E`,
     valueInputOption: 'USER_ENTERED',
     insertDataOption: 'INSERT_ROWS',
     requestBody: { values },


### PR DESCRIPTION
## Summary
- Ensure Tesorería rows include the "quien" field and expand the sheet range accordingly
- Cover treasury row creation with a new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e84b39f883298f050d8d95d62ca1