### PR TITLE
Synchronize Tesorería movements on record updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -314,7 +314,6 @@ async function saveDay() {
         const existing = loadDay(currentEditKey);
         sheetId = existing?.sheetId;
     }
-    const wasNewRecord = !sheetId;
 
     const dayData = {
         fecha,
@@ -374,7 +373,7 @@ async function saveDay() {
                 dayData.sheetId = sheetId;
                 saveDayData(fecha, dayData, currentEditKey);
             }
-            if (wasNewRecord && sheetId && currentMovimientos.length) {
+            if (sheetId) {
                 try {
                     await fetch('/api/append-tesoreria', {
                         method: 'POST',


### PR DESCRIPTION
## Summary
- remove outdated Tesorería rows before adding updated movements
- always send Tesorería movements to the backend when saving a day

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8eb359dc883299a1b2b5484c7f1fa