### PR TITLE
Widen Registro del Día column and enable horizontal scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
             </div>
 
             <!-- Panel Derecho: Historial y Exportación -->
-            <div class="panel">
+            <div class="panel historial-panel">
                 <h2>📋 Historial y Exportación</h2>
                 
                 <!-- Filtros -->

--- a/styles.css
+++ b/styles.css
@@ -112,7 +112,7 @@ body {
 
     .main-content {
         flex: 1;
-        grid-template-columns: 260px 1fr;
+        grid-template-columns: 360px 1fr;
         overflow: hidden;
     }
 
@@ -129,6 +129,11 @@ body {
     box-shadow: 0 4px 20px rgba(0,0,0,0.08);
     overflow-x: hidden;
     touch-action: pan-y;
+}
+
+.historial-panel {
+    overflow-x: auto;
+    touch-action: pan-x pan-y;
 }
 
 .panel h2 {
@@ -309,7 +314,7 @@ input[type="date"]:valid::-webkit-datetime-edit {
     }
     
     .main-content {
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: 360px 1fr;
         gap: 25px;
     }
     


### PR DESCRIPTION
## Summary
- Increase Registro del Día panel width on desktop and iPad for better visibility of movement name and amount
- Allow Historial y Exportación panel to scroll horizontally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8fd78eb388329b38ff2ff0210bbfe