### PR TITLE
Expand small button tap area

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -248,9 +248,9 @@ input[type="date"]:valid::-webkit-datetime-edit {
 }
 
 .btn-small {
-    padding: 8px 16px;
+    padding: 10px 16px;
     font-size: 14px;
-    min-height: 36px;
+    min-height: 44px;
 }
 
 .btn-group {
@@ -382,9 +382,9 @@ input[type="date"]:valid::-webkit-datetime-edit {
     }
     
     .btn-small {
-        padding: 6px 12px;
+        padding: 8px 12px;
         font-size: 13px;
-        min-height: 32px;
+        min-height: 44px;
     }
 }
 


### PR DESCRIPTION
## Summary
- increase .btn-small min-height to 44px and adjust padding
- keep iPad landscape variant aligned with new minimum height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8fed0ee2083299c3def2db195010a