### PR TITLE
Abreviar tipos de movimiento

### DIFF
--- a/__tests__/renderMovimientos.test.js
+++ b/__tests__/renderMovimientos.test.js
@@ -22,5 +22,6 @@ describe('renderMovimientos', () => {
         renderMovimientos(movimientos);
         expect(container.innerHTML).toContain('movimiento-item');
         expect(container.innerHTML).toContain('Ana');
+        expect(container.innerHTML).toContain('ENT');
     });
 });

--- a/styles.css
+++ b/styles.css
@@ -276,7 +276,7 @@ input[type="date"]:valid::-webkit-datetime-edit {
 
 .movimiento-item {
     display: grid;
-    grid-template-columns: 120px minmax(0, 2fr) minmax(0, 1fr) 60px;
+    grid-template-columns: 60px minmax(0, 1fr) auto 60px;
     gap: 10px;
     align-items: center;
     padding: 10px;
@@ -286,10 +286,14 @@ input[type="date"]:valid::-webkit-datetime-edit {
     font-size: 14px;
 }
 
-.movimiento-item span {
+.movimiento-item .movimiento-nombre {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.movimiento-item .movimiento-importe {
+    white-space: nowrap;
 }
 
 .movimiento-form {
@@ -339,7 +343,7 @@ input[type="date"]:valid::-webkit-datetime-edit {
         border-radius: 8px;
         margin-top: 15px;
     }
-    
+
     .movimiento-form select,
     .movimiento-form input[type="text"] {
         font-size: 16px;
@@ -349,10 +353,10 @@ input[type="date"]:valid::-webkit-datetime-edit {
         border-radius: 8px;
         width: 100%;
     }
-    
+
     .movimiento-item {
         display: grid;
-        grid-template-columns: 120px minmax(0, 2fr) minmax(0, 1fr) 80px;
+        grid-template-columns: 60px minmax(0, 1fr) auto 60px;
         gap: 15px;
         align-items: center;
         padding: 12px;
@@ -558,7 +562,13 @@ tr:hover {
         font-size: 1.8em;
     }
 
-    .movimiento-item,
+    .movimiento-item {
+        display: grid;
+        grid-template-columns: 60px minmax(0, 1fr) auto 40px;
+        gap: 8px;
+        font-size: 12px;
+    }
+
     .movimiento-form {
         display: grid;
         grid-template-columns: 70px minmax(0, 1fr) 70px 40px;
@@ -714,7 +724,12 @@ tr:hover {
         font-size: 1em;
     }
 
-    .movimiento-item,
+    .movimiento-item {
+        grid-template-columns: 50px minmax(0, 1fr) auto 40px;
+        gap: 6px;
+        font-size: 12px;
+    }
+
     .movimiento-form {
         grid-template-columns: 60px minmax(0, 1fr) 60px 40px;
         gap: 6px;

--- a/ui.js
+++ b/ui.js
@@ -49,7 +49,7 @@ export function renderMovimientos(movimientos) {
 
             return `
         <div class="movimiento-item">
-            <strong>${mov.tipo === 'entrada' ? 'Entrada' : 'Salida'}</strong>
+            <strong class="movimiento-tipo">${mov.tipo === 'entrada' ? 'ENT' : 'SAL'}</strong>
             <span class="movimiento-nombre">${nombre}</span>
             <span class="text-right movimiento-importe">${formatCurrency(importe)} €</span>
             <button type="button" class="btn btn-danger btn-small" onclick="removeMovimiento(${index})">🗑️</button>


### PR DESCRIPTION
## Resumen
- Mostrar los movimientos como **ENT** o **SAL** y conservar el nombre y el importe visibles.
- Rediseño del grid de movimientos para que haya más espacio para el nombre y el importe.
- Prueba unitaria actualizada para validar la nueva abreviatura.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a907dbec348329874ad9e5cfd53967