### PR TITLE
Fix difference calculation sign

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -26,11 +26,11 @@ describe('computeTotals', () => {
             { tipo: 'entrada', importe: 2 }
         ];
         const result = computeTotals(100, 50, movimientos, 120);
-        expect(result).toEqual({ entradas: 12, salidas: 5, total: 157, diff: -37 });
+        expect(result).toEqual({ entradas: 12, salidas: 5, total: 157, diff: 37 });
     });
 
     test('handles string numbers and empty movimientos', () => {
         const result = computeTotals('1.000,00', '200,00', [], '800');
-        expect(result).toEqual({ entradas: 0, salidas: 0, total: 1200, diff: -400 });
+        expect(result).toEqual({ entradas: 0, salidas: 0, total: 1200, diff: 400 });
     });
 });

--- a/utils/computeTotals.js
+++ b/utils/computeTotals.js
@@ -22,7 +22,7 @@ export function computeTotals(apertura, ingresos, movimientos, cierre) {
     }
 
     const total = aperturaNum + ingresosNum + entradas - salidas;
-    const diff = cierreNum - total;
+    const diff = total - cierreNum;
 
     return {
         entradas,


### PR DESCRIPTION
## Summary
- compute difference using total minus closing amount to show surplus correctly
- adjust unit tests for updated diff logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a90c64dba48329be0a2863d01a586e