### PR TITLE
feat: add automatic dark mode with manual toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,45 @@ if ('serviceWorker' in navigator) {
     });
 }
 
+function setTheme(theme) {
+    document.body.classList.toggle("dark", theme === "dark");
+    const btn = document.getElementById("themeToggle");
+    if (btn) btn.textContent = theme === "dark" ? "Modo claro" : "Modo oscuro";
+}
+
+async function autoTheme() {
+    try {
+        const res = await fetch("https://api.sunrise-sunset.org/json?lat=40.4168&lng=-3.7038&formatted=0");
+        const data = await res.json();
+        const sunset = new Date(new Date(data.results.sunset).toLocaleString("en-US", { timeZone: "Europe/Madrid" }));
+        const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Europe/Madrid" }));
+        setTheme(now > sunset ? "dark" : "light");
+    } catch (err) {
+        setTheme("light");
+    }
+}
+
+function initTheme() {
+    const stored = localStorage.getItem("theme");
+    if (stored) {
+        setTheme(stored);
+    } else {
+        autoTheme();
+    }
+    const toggle = document.getElementById("themeToggle");
+    if (toggle) {
+        toggle.addEventListener("click", () => {
+            const newTheme = document.body.classList.contains("dark") ? "light" : "dark";
+            setTheme(newTheme);
+            localStorage.setItem("theme", newTheme);
+        });
+    }
+}
+
+if (typeof document !== "undefined") {
+    document.addEventListener("DOMContentLoaded", initTheme);
+}
+
 // Variables globales
 let currentMovimientos = [];
 let filteredDates = null;

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
         <div class="header">
             <h1>📊 Gestión de Caja LBJ</h1>
             <p>Control de efectivo para sucursales</p>
+            <button id="themeToggle" class="btn btn-secondary btn-small">Modo oscuro</button>
             <button id="changeSucursalBtn" class="btn btn-secondary btn-small" onclick="changeSucursal()">Cambiar sucursal</button>
             <div id="currentSucursal" class="current-sucursal"></div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,12 @@ body {
     right: 20px;
 }
 
+#themeToggle {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+}
+
 .current-sucursal {
     position: absolute;
     top: 60px;
@@ -797,4 +803,37 @@ tr:hover {
     .table-container td.text-center {
         justify-content: center;
     }
+}
+/* Dark mode styles */
+body.dark {
+    --color-claro: #1a1a1a;
+    --color-borde: #333;
+    --color-gris: #adb5bd;
+    --color-gris-oscuro: #ced4da;
+    color: #f1f1f1;
+    background-color: #1a1a1a;
+}
+
+body.dark .header {
+    background: linear-gradient(135deg, var(--color-primario-oscuro) 0%, var(--color-primario) 100%);
+    color: #fff;
+}
+
+body.dark .panel {
+    background-color: #2c2c2c;
+    color: #f1f1f1;
+}
+
+body.dark .table-container tr {
+    background: #2c2c2c;
+}
+
+body.dark .table-container td,
+body.dark .table-container th {
+    color: #f1f1f1;
+    border-color: #3a3a3a;
+}
+
+body.dark .dropdown-menu button:hover {
+    background: #333;
 }


### PR DESCRIPTION
## Summary
- add header button to toggle dark/light mode manually
- compute Spain sunset to enable dark theme automatically
- style dark theme and toggle button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9107647fc8329951df606ece05b23