### PR TITLE
Insert new records at top of Google Sheets

### DIFF
--- a/api/googleSheets.js
+++ b/api/googleSheets.js
@@ -105,14 +105,30 @@ export async function appendRecord(data) {
     const client = await getSheetsClient();
     const id = await getNextId();
     const values = [buildRow(id, data)];
-    await client.spreadsheets.values.append({
+    await client.spreadsheets.batchUpdate({
       spreadsheetId: SHEET_ID,
-      range: `${SHEET_NAME}!A:N`,
+      requestBody: {
+        requests: [
+          {
+            insertDimension: {
+              range: {
+                sheetId: sheetNumericId,
+                dimension: 'ROWS',
+                startIndex: 1,
+                endIndex: 2,
+              },
+            },
+          },
+        ],
+      },
+    });
+    await client.spreadsheets.values.update({
+      spreadsheetId: SHEET_ID,
+      range: `${SHEET_NAME}!A2:N2`,
       valueInputOption: 'USER_ENTERED',
-      insertDataOption: 'INSERT_ROWS',
       requestBody: { values },
     });
-    console.log(`Row appended with ID ${id}`);
+    console.log(`Row inserted with ID ${id}`);
     return id;
   } catch (err) {
     console.error('Append failed', err);
@@ -203,11 +219,27 @@ export async function appendTesoreriaMovimientos(
     const values = movimientos.map((mov, idx) =>
       buildTesoreriaRow(`${cierreId}-${idx + 1}`, fecha, mov)
     );
-    await client.spreadsheets.values.append({
+    await client.spreadsheets.batchUpdate({
       spreadsheetId: SHEET_ID,
-      range: `${TESORERIA_SHEET_NAME}!A:E`,
+      requestBody: {
+        requests: [
+          {
+            insertDimension: {
+              range: {
+                sheetId: tesoreriaSheetNumericId,
+                dimension: 'ROWS',
+                startIndex: 1,
+                endIndex: 1 + values.length,
+              },
+            },
+          },
+        ],
+      },
+    });
+    await client.spreadsheets.values.update({
+      spreadsheetId: SHEET_ID,
+      range: `${TESORERIA_SHEET_NAME}!A2:E${1 + values.length}`,
       valueInputOption: 'USER_ENTERED',
-      insertDataOption: 'INSERT_ROWS',
       requestBody: { values },
     });
   }

--- a/docs/google-sheets.md
+++ b/docs/google-sheets.md
@@ -2,6 +2,10 @@
 
 Este módulo permite sincronizar los cierres de caja con la hoja de cálculo de Google Sheets.
 
+Los registros nuevos se insertan en la primera fila disponible de cada hoja,
+desplazando hacia abajo los datos existentes tanto en **LBJ** como en
+**Tesorería**.
+
 ## Configuración
 
 1. **Credenciales**: guardar el JSON de la cuenta de servicio en un archivo local y establecer la variable de entorno `GSHEET_CREDENTIALS` con la ruta al archivo.


### PR DESCRIPTION
## Summary
- Insert rows at the top of LBJ sheet so new records appear above existing data.
- Insert rows at the top of the Tesorería sheet for new movements, shifting previous entries downward.
- Document that both sheets prepend new entries instead of appending at the end.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a91504c6948329b316161cafdfb91b