### PR TITLE
Display only icon in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,7 @@
     </div>
     <div class="container">
         <div class="header">
-            <h1>📊 Gestión de Caja LBJ</h1>
-            <p>Control de efectivo para sucursales</p>
+            <img src="./icon-180.png" alt="Caja LBJ" class="header-logo">
             <button id="themeToggle" class="btn btn-secondary btn-small">Modo oscuro</button>
             <button id="changeSucursalBtn" class="btn btn-secondary btn-small" onclick="changeSucursal()">Cambiar sucursal</button>
             <div id="currentSucursal" class="current-sucursal"></div>

--- a/styles.css
+++ b/styles.css
@@ -96,9 +96,12 @@ body {
     color: white;
 }
 
-.header h1 {
-    font-size: 2.2em;
-    margin-bottom: 10px;
+
+.header-logo {
+    width: 90px;
+    height: 90px;
+    display: block;
+    margin: 0 auto 10px;
 }
 
 .main-content {


### PR DESCRIPTION
## Summary
- Replace header title and description with app icon
- Style header icon for centered display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a91978d6088329acca0c9165094421