### PR TITLE
Refactor header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,11 @@
     <div class="container">
         <div class="header">
             <img src="./icon-180.png" alt="Caja LBJ" class="header-logo">
-            <button id="themeToggle" class="btn btn-secondary btn-small">Modo oscuro</button>
-            <button id="changeSucursalBtn" class="btn btn-secondary btn-small" onclick="changeSucursal()">Cambiar sucursal</button>
-            <div id="currentSucursal" class="current-sucursal"></div>
+            <div class="header-actions">
+                <button id="themeToggle" class="btn btn-secondary btn-small">Modo oscuro</button>
+                <button id="changeSucursalBtn" class="btn btn-secondary btn-small" onclick="changeSucursal()">Cambiar sucursal</button>
+                <div id="currentSucursal" class="current-sucursal"></div>
+            </div>
         </div>
 
         <div class="tests-panel" id="testsPanel">

--- a/styles.css
+++ b/styles.css
@@ -65,7 +65,10 @@ body {
 }
 
 .header {
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
     margin: 0 0 30px;
     padding: 20px;
     padding-top: calc(20px + env(safe-area-inset-top));
@@ -73,35 +76,24 @@ body {
     color: white;
     border-radius: 0 0 12px 12px;
     box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-    position: relative;
 }
 
-#changeSucursalBtn {
-    position: absolute;
-    top: calc(20px + env(safe-area-inset-top));
-    right: 20px;
-}
-
-#themeToggle {
-    position: absolute;
-    top: calc(20px + env(safe-area-inset-top));
-    left: 20px;
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
 }
 
 .current-sucursal {
-    position: absolute;
-    top: calc(20px + env(safe-area-inset-top));
-    right: 20px;
     font-size: 1em;
     color: white;
 }
-
 
 .header-logo {
     max-width: 90px;
     height: auto;
     display: block;
-    margin: 0 auto 10px;
+    margin: 0;
 }
 
 .main-content {
@@ -721,7 +713,7 @@ tr:hover {
     .header-logo {
         max-width: 60px;
         height: auto;
-        margin: 0 auto 8px;
+        margin: 0;
     }
 
     .header h1 {
@@ -768,11 +760,6 @@ tr:hover {
         font-size: 13px;
     }
 
-    #changeSucursalBtn,
-    #themeToggle,
-    .current-sucursal {
-        top: calc(15px + env(safe-area-inset-top));
-    }
 
     /* Presentación alternativa de tablas en móviles */
     .table-container table,


### PR DESCRIPTION
## Summary
- Group header buttons in a new `header-actions` container and keep logo separate
- Make header a flex container and remove absolute positioning in favor of gap spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a96433e9a483299d4e6f8ecb549484