### PR TITLE
Corrige cálculo de diferencia de caja

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -26,11 +26,11 @@ describe('computeTotals', () => {
             { tipo: 'entrada', importe: 2 }
         ];
         const result = computeTotals(100, 50, movimientos, 120);
-        expect(result).toEqual({ entradas: 12, salidas: 5, total: 157, diff: 37 });
+        expect(result).toEqual({ entradas: 12, salidas: 5, total: 157, diff: -37 });
     });
 
     test('handles string numbers and empty movimientos', () => {
         const result = computeTotals('1.000,00', '200,00', [], '800');
-        expect(result).toEqual({ entradas: 0, salidas: 0, total: 1200, diff: 400 });
+        expect(result).toEqual({ entradas: 0, salidas: 0, total: 1200, diff: -400 });
     });
 });

--- a/app.js
+++ b/app.js
@@ -952,10 +952,10 @@ function runTests() {
             name: 'Test 1: Cálculo básico sin movimientos',
             test: () => {
                 const result = computeTotals(100, 50, [], 120);
-                return result.entradas === 0 && 
-                       result.salidas === 0 && 
-                       result.total === 150 && 
-                       result.diff === 30;
+                return result.entradas === 0 &&
+                       result.salidas === 0 &&
+                       result.total === 150 &&
+                       result.diff === -30;
             }
         },
         {

--- a/utils/computeTotals.js
+++ b/utils/computeTotals.js
@@ -22,7 +22,9 @@ export function computeTotals(apertura, ingresos, movimientos, cierre) {
     }
 
     const total = aperturaNum + ingresosNum + entradas - salidas;
-    const diff = total - cierreNum;
+    // diff > 0 indica que hay más dinero en caja del esperado (sobra)
+    // diff < 0 indica que falta dinero respecto al esperado
+    const diff = cierreNum - total;
 
     return {
         entradas,


### PR DESCRIPTION
## Summary
- Corrige el signo de `diff` en `computeTotals` para que valores positivos representen sobra de efectivo y valores negativos indiquen falta.
- Ajusta pruebas unitarias y tests internos para reflejar la nueva lógica de cálculo.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa24f9167c83299816ed0c5b8c0faa