### PR TITLE
feat: add header image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -73,7 +73,8 @@ body {
     margin: 0 0 30px;
     padding: 20px;
     padding-top: calc(20px + env(safe-area-inset-top));
-    background: url('https://images.unsplash.com/photo-1583943486450-8b3d91b110d5?auto=format&fit=crop&w=1200&q=80') center/cover no-repeat;
+    min-height: 180px;
+    background: url('./IMG_1568.jpg') center/cover no-repeat;
     color: white;
     border-radius: 0 0 12px 12px;
     box-shadow: 0 4px 15px rgba(0,0,0,0.1);
@@ -83,8 +84,25 @@ body {
     content: "";
     position: absolute;
     inset: 0;
-    background: rgba(0, 0, 0, 0.3);
+    background: rgba(0, 0, 0, 0.5);
     border-radius: inherit;
+}
+
+.header .btn-secondary {
+    background-color: rgba(0, 0, 0, 0.6);
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.header .btn-secondary:hover {
+    background-color: rgba(0, 0, 0, 0.8);
+}
+
+@media (max-width: 600px) {
+    .header {
+        min-height: 120px;
+        padding: 15px;
+    }
 }
 
 .header-actions {


### PR DESCRIPTION
## Summary
- add local header background image with dark overlay
- tweak header buttons for readability and mobile spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3b5e0f588329a0e51e32dfed3b2a