### PR TITLE
feat: normalize numeric inputs for iPad

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                         <div class="form-group">
                             <label for="apertura">Apertura de caja</label>
                             <div class="currency">
-                                <input type="number" id="apertura" placeholder="0,00" inputmode="decimal" step="0.01">
+                                <input id="apertura" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                             </div>
                         </div>
                         
@@ -87,7 +87,7 @@
                     <div class="form-group">
                         <label for="ingresos">Ingresos en efectivo (Exora)</label>
                         <div class="currency">
-                            <input type="number" id="ingresos" placeholder="0,00" inputmode="decimal" step="0.01">
+                            <input id="ingresos" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                         </div>
                     </div>
 
@@ -95,14 +95,14 @@
                         <div class="form-group">
                             <label for="ingresosTarjetaExora">Ingresos en tarjeta (Exora)</label>
                             <div class="currency">
-                                <input type="number" id="ingresosTarjetaExora" placeholder="0,00" inputmode="decimal" step="0.01">
+                                <input id="ingresosTarjetaExora" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                             </div>
                         </div>
 
                         <div class="form-group">
                             <label for="ingresosTarjetaDatafono">Ingresos en tarjeta (Datáfono)</label>
                             <div class="currency">
-                                <input type="number" id="ingresosTarjetaDatafono" placeholder="0,00" inputmode="decimal" step="0.01">
+                                <input id="ingresosTarjetaDatafono" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                             </div>
                         </div>
                     </div>
@@ -124,7 +124,7 @@
                                 </select>
                                 <label for="importeMovimiento" class="visually-hidden">Importe del movimiento</label>
                                 <div class="currency">
-                                    <input type="number" id="importeMovimiento" placeholder="0,00" inputmode="decimal" step="0.01" tabindex="0">
+                                    <input id="importeMovimiento" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00" tabindex="0">
                                 </div>
                                 <button type="button" class="btn btn-primary btn-small" onclick="addMovimiento()" tabindex="0">+</button>
                             </div>
@@ -135,7 +135,7 @@
                         <div class="form-group">
                             <label for="cierre">Cierre de caja</label>
                             <div class="currency">
-                                <input type="number" id="cierre" placeholder="0,00" inputmode="decimal" step="0.01">
+                                <input id="cierre" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                             </div>
                         </div>
                         


### PR DESCRIPTION
## Summary
- ensure currency and movement inputs use text with decimal keyboard on iPad
- add utilities to restrict numeric entry and normalize numbers before API calls
- wrap buildPayloadFromForm to parse money and safe numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4ba560b08329aa28c7153ef4cec5