### PR TITLE
feat: add iPad numeric keypad

### DIFF
--- a/app.js
+++ b/app.js
@@ -1380,3 +1380,81 @@ if (typeof buildPayloadFromForm !== 'function') {
 
 // Ejecuta el cableado (sin romper wireUI existentes)
 try { wireNumericKeyboards(); } catch(e) { console.warn('wireNumericKeyboards()', e); }
+
+// === Keypad numérico para iPad (mini-calculadora) ===
+const isIPad = /iPad/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
+(function initNumPad(){
+  if (!isIPad) return; // en iPhone/desktop no se activa; usan teclado nativo
+  let activeInput = null;
+  let pad = null;
+
+  function buildPad(){
+    pad = document.createElement('div');
+    pad.className = 'numpad hidden';
+    pad.innerHTML = `
+      <div class="numpad-grid">
+        <button data-k="7">7</button><button data-k="8">8</button><button data-k="9">9</button><button class="del" data-k="back">⌫</button>
+        <button data-k="4">4</button><button data-k="5">5</button><button data-k="6">6</button><button data-k="clear">C</button>
+        <button data-k="1">1</button><button data-k="2">2</button><button data-k="3">3</button><button class="ok" data-k="ok">OK</button>
+        <button class="wide" data-k="0">0</button><button data-k="sep">,</button><button data-k="minus">±</button>
+      </div>`;
+    document.body.appendChild(pad);
+
+    pad.addEventListener('click', (e)=>{
+      const b = e.target.closest('button'); if(!b || !activeInput) return;
+      const kind = b.getAttribute('data-k');
+      const mode = activeInput.dataset.numpad || 'decimal';
+      let v = activeInput.value || '';
+      const set = (nv)=> { activeInput.value = nv; };
+      switch(kind){
+        case 'ok':   hidePad(); activeInput.dispatchEvent(new Event('change',{bubbles:true})); break;
+        case 'back': set(v.slice(0, -1)); break;
+        case 'clear':set(''); break;
+        case 'sep':  if (mode !== 'int' && !v.includes(',') && !v.includes('.')) set(v + ','); break;
+        case 'minus': if (mode === 'int' || mode === 'decimal') set(v.startsWith('-') ? v.slice(1) : ('-' + v)); break;
+        default:     set(v + kind);
+      }
+    });
+  }
+
+  function showPad(input){
+    if (!pad) buildPad();
+    activeInput = input;
+    if (typeof parseNum === 'function' && parseNum(input.value) === 0) {
+      input.value = '';
+    }
+    document.body.classList.add('numpad-open');
+    pad.classList.remove('hidden');
+  }
+  function hidePad(){
+    activeInput = null;
+    if (pad) pad.classList.add('hidden');
+    document.body.classList.remove('numpad-open');
+  }
+
+  // Preparar inputs con data-numpad
+  document.querySelectorAll('input[data-numpad]').forEach(inp=>{
+    inp.setAttribute('readonly', 'readonly');   // evita teclado del sistema en iPad
+    inp.addEventListener('focus', ()=> showPad(inp));
+    inp.addEventListener('click', ()=> showPad(inp));
+  });
+
+  // Cerrar al tocar fuera
+  document.addEventListener('click', (e)=>{
+    if (!pad || pad.classList.contains('hidden')) return;
+    if (e.target.closest('.numpad') || e.target.closest('input[data-numpad]')) return;
+    hidePad();
+  });
+  // Cerrar con Escape (si hay teclado hardware)
+  document.addEventListener('keydown', (e)=> { if (e.key === 'Escape') hidePad(); });
+})();
+
+// Normalizador de dinero (opcional, por si no existe ya)
+if (typeof parseMoney !== 'function') {
+  window.parseMoney = function parseMoney(v) {
+    if (typeof v !== 'string') v = String(v ?? '');
+    v = v.trim().replace(/\./g, '').replace(',', '.');
+    const n = Number(v); return Number.isFinite(n) ? n : 0;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                         <div class="form-group">
                             <label for="apertura">Apertura de caja</label>
                             <div class="currency">
-                                <input id="apertura" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
+                                <input id="apertura" data-numpad="decimal" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                             </div>
                         </div>
                         
@@ -87,7 +87,7 @@
                     <div class="form-group">
                         <label for="ingresos">Ingresos en efectivo (Exora)</label>
                         <div class="currency">
-                            <input id="ingresos" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
+                            <input id="ingresos" data-numpad="decimal" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                         </div>
                     </div>
 
@@ -95,14 +95,14 @@
                         <div class="form-group">
                             <label for="ingresosTarjetaExora">Ingresos en tarjeta (Exora)</label>
                             <div class="currency">
-                                <input id="ingresosTarjetaExora" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
+                                <input id="ingresosTarjetaExora" data-numpad="decimal" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                             </div>
                         </div>
 
                         <div class="form-group">
                             <label for="ingresosTarjetaDatafono">Ingresos en tarjeta (Datáfono)</label>
                             <div class="currency">
-                                <input id="ingresosTarjetaDatafono" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
+                                <input id="ingresosTarjetaDatafono" data-numpad="decimal" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                             </div>
                         </div>
                     </div>
@@ -135,7 +135,7 @@
                         <div class="form-group">
                             <label for="cierre">Cierre de caja</label>
                             <div class="currency">
-                                <input id="cierre" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
+                                <input id="cierre" data-numpad="decimal" type="text" inputmode="decimal" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="0,00">
                             </div>
                         </div>
                         

--- a/styles.css
+++ b/styles.css
@@ -854,3 +854,16 @@ body.dark .table-container th {
 body.dark .dropdown-menu button:hover {
     background: #333;
 }
+
+/* === Keypad numérico para iPad === */
+.numpad {
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 9999;
+  background: #111; padding: 10px 12px; box-shadow: 0 -8px 24px rgba(0,0,0,.3);
+}
+.numpad-grid { display: grid; gap: 8px; grid-template-columns: repeat(4, minmax(0,1fr)); }
+.numpad button { font-size: 22px; padding: 14px 0; border: 0; border-radius: 10px; background: #222; color: #fff; }
+.numpad .ok { background: #2d7; }
+.numpad .del { background: #c33; }
+.numpad .wide { grid-column: span 2; }
+.hidden { display: none !important; }
+body.numpad-open { padding-bottom: 260px; }


### PR DESCRIPTION
## Summary
- add `data-numpad` attributes to cash and card inputs
- implement floating numeric keypad for iPad and supporting styles
- clear zero-valued fields on keypad open to avoid starting from third decimal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa514a058483298f67e502b82597fc