### PR TITLE
Ensure iPad numpad clears zero value before entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -1423,6 +1423,7 @@ const isIPad = /iPad/.test(navigator.userAgent) || (navigator.platform === 'MacI
     activeInput = input;
     document.body.classList.add('numpad-open');
     pad.classList.remove('hidden');
+    if (typeof parseNum === 'function' && parseNum(input.value) === 0) input.value = '';
   }
   function hidePad(){
     activeInput = null;


### PR DESCRIPTION
## Summary
- Clear value when opening iPad custom numpad if it's zero to prevent input starting at decimal positions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa5520b9a083299ae28fd539f7123b