### PR TITLE
Improve numpad touch handling and zoom lock

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -868,3 +868,9 @@ body.dark .dropdown-menu button:hover {
 .hidden { display: none !important; }
 body.numpad-open { padding-bottom: 260px; }
 html, body, button, .numpad button { touch-action: manipulation; }
+.numpad button {
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
## Summary
- Use pointerdown/touchstart for instant numpad input and stop propagation
- Clear zeroish values when showing the keypad
- Allow rapid keypad taps while still blocking double-tap zoom elsewhere
- Prevent text selection and tap highlight on numpad buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa5c7d58dc8329ba840be3b459babc