### PR TITLE
Move day controls to fixed bottom bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,10 +241,10 @@
     </div>
 
     <div class="action-bar">
-        <button type="button" class="btn btn-success" onclick="saveDay()">💾 Guardar</button>
-        <button type="button" class="btn btn-primary" onclick="newDay()">🆕 Nuevo</button>
-        <button type="button" class="btn btn-danger" onclick="deleteCurrentDay()">🗑️ Borrar</button>
-        <button type="button" class="btn" onclick="runTests()">🔧 Tests</button>
+        <button type="button" class="btn btn-success" onclick="saveDay()">Guardar</button>
+        <button type="button" class="btn btn-primary" onclick="newDay()">Nuevo</button>
+        <button type="button" class="btn btn-danger" onclick="deleteCurrentDay()">Borrar</button>
+        <button type="button" class="btn" onclick="runTests()">Tests</button>
     </div>
 
     <script type="module" src="app.js"></script>

--- a/index.html
+++ b/index.html
@@ -244,7 +244,6 @@
         <button type="button" class="btn btn-success" onclick="saveDay()">Guardar</button>
         <button type="button" class="btn btn-primary" onclick="newDay()">Nuevo</button>
         <button type="button" class="btn btn-danger" onclick="deleteCurrentDay()">Borrar</button>
-        <button type="button" class="btn" onclick="runTests()">Tests</button>
     </div>
 
     <script type="module" src="app.js"></script>

--- a/index.html
+++ b/index.html
@@ -150,13 +150,6 @@
                     <div id="diferenciaDisplay" class="diferencia" role="status" aria-live="polite"></div>
 
                     <div id="diferenciaTarjetaDisplay" class="diferencia" role="status" aria-live="polite"></div>
-
-                    <div class="btn-group">
-                        <button type="button" class="btn btn-success" onclick="saveDay()">💾 Guardar día</button>
-                        <button type="button" class="btn btn-primary" onclick="newDay()">🆕 Nuevo día</button>
-                        <button type="button" class="btn btn-danger" onclick="deleteCurrentDay()">🗑️ Borrar día</button>
-                        <button type="button" class="btn" onclick="runTests()">🔧 Tests</button>
-                    </div>
                 </form>
             </div>
 
@@ -245,6 +238,13 @@
                 </div>
             </div>
         </div>
+    </div>
+
+    <div class="action-bar">
+        <button type="button" class="btn btn-success" onclick="saveDay()">💾 Guardar</button>
+        <button type="button" class="btn btn-primary" onclick="newDay()">🆕 Nuevo</button>
+        <button type="button" class="btn btn-danger" onclick="deleteCurrentDay()">🗑️ Borrar</button>
+        <button type="button" class="btn" onclick="runTests()">🔧 Tests</button>
     </div>
 
     <script type="module" src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -273,7 +273,7 @@ input[type="date"]:valid::-webkit-datetime-edit {
     left: 0;
     right: 0;
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
     gap: 10px;
     padding: 10px;
     background: #fff;

--- a/styles.css
+++ b/styles.css
@@ -43,7 +43,7 @@ body {
     color: #333;
     background-color: var(--color-claro);
     overflow-x: hidden;
-    padding-bottom: env(safe-area-inset-bottom);
+    padding-bottom: calc(80px + env(safe-area-inset-bottom));
 }
 
 .visually-hidden {
@@ -265,6 +265,20 @@ input[type="date"]:valid::-webkit-datetime-edit {
     gap: 10px;
     flex-wrap: wrap;
     margin-top: 20px;
+}
+
+.action-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    padding: 10px;
+    background: #fff;
+    border-top: 1px solid #ccc;
+    z-index: 1000;
 }
 
 .movimientos-container {
@@ -811,7 +825,7 @@ tr:hover {
 .numpad .del { background: #c33; }
 .numpad .wide { grid-column: span 2; }
 .hidden { display: none !important; }
-body.numpad-open { padding-bottom: 260px; }
+body.numpad-open { padding-bottom: calc(340px + env(safe-area-inset-bottom)); }
 html, body, button, .numpad button { touch-action: manipulation; }
 .numpad button {
   touch-action: manipulation;


### PR DESCRIPTION
## Summary
- Rename day action buttons and relocate them to a persistent bottom bar
- Style new bottom bar and adjust page padding for visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab1e82e7c83298602a7d2c974a04c