### PR TITLE
Evitar guardar días vacíos

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -166,21 +166,34 @@ describe('saveDay', () => {
             ingresosTarjetaExora: { value: '0' },
             ingresosTarjetaDatafono: { value: '0' },
             cierre: { value: '0' },
-            responsableCierre: { value: '' }
+            responsableCierre: { value: '' },
+            cajaForm: { reset: jest.fn() },
+            diferenciaDisplay: { className: '', innerHTML: '' },
+            currentSucursal: { textContent: '' }
         };
         global.document = {
             getElementById: (id) => elements[id],
             addEventListener: jest.fn()
         };
+        window.newDay();
+        showAlert.mockClear();
     });
 
     test('saveDay almacena hora de guardado', async () => {
         store['sucursal'] = 'Central';
+        elements.ingresos.value = '10';
         await window.saveDay();
         const index = JSON.parse(store['caja:index']);
         const key = index[0];
         const saved = JSON.parse(store[`caja:${key}`]);
         expect(saved.horaGuardado).toBeDefined();
+    });
+
+    test('saveDay no guarda cuando todos los valores son cero y no hay movimientos', async () => {
+        store['sucursal'] = 'Central';
+        await window.saveDay();
+        expect(store['caja:index']).toBeUndefined();
+        expect(showAlert).toHaveBeenCalledWith('No hay datos para guardar', 'warning');
     });
 });
 

--- a/app.js
+++ b/app.js
@@ -323,7 +323,20 @@ async function saveDay() {
         showAlert('Por favor, completa la fecha y sucursal', 'danger');
         return;
     }
-    
+
+    const isEmptyDay =
+        apertura === 0 &&
+        ingresos === 0 &&
+        ingresosTarjetaExora === 0 &&
+        ingresosTarjetaDatafono === 0 &&
+        cierre === 0 &&
+        currentMovimientos.length === 0;
+
+    if (isEmptyDay) {
+        showAlert('No hay datos para guardar', 'warning');
+        return;
+    }
+
     let sheetId;
     if (currentEditKey) {
         const existing = loadDay(currentEditKey);


### PR DESCRIPTION
## Summary
- No guardar un día cuando todos los importes son 0 y no hay movimientos de tesorería
- Añadir pruebas que validan esta lógica y el almacenamiento de la hora de guardado

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab9d7d33483299d7a64bbfebe6c4f