### PR TITLE
feat: apply brand color palette for refreshed UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     <div class="container">
         <div class="header hero">
             <div class="header-brand">
-                <span>Gestión de Caja Exora</span>
+                <span>Gestión de <span class="brand-accent">Caja</span> Exora</span>
             </div>
             <div class="header-actions">
                 <button id="themeToggle" class="btn" aria-label="Cambiar tema">🌙</button>

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Caja LBJ">
-    <meta name="theme-color" content="#b08d57">
+    <meta name="theme-color" content="#555bf6">
     
     <!-- Icon for iPad home screen -->
     <link rel="apple-touch-icon" sizes="180x180" href="./icon-180.png">
@@ -21,7 +21,7 @@
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="styles.css?v=2">
+    <link rel="stylesheet" href="styles.css?v=3">
 
 </head>
 <body>
@@ -43,6 +43,9 @@
     </div>
     <div class="container">
         <div class="header hero">
+            <div class="header-brand">
+                <span>Gestión de <span class="brand-accent">Caja</span> Exora</span>
+            </div>
             <div class="header-actions">
                 <button id="themeToggle" class="btn" aria-label="Cambiar tema">🌙</button>
                 <button id="changeSucursalBtn" class="btn btn-primary" onclick="changeSucursal()">Cambiar sucursal</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,29 +5,48 @@
 }
 
 :root {
-    --color-primario: #5865f2;
-    --color-primario-oscuro: #3d4ae0;
-    --color-secundario: #7789ff;
+    --color-primario: #555bf6;
+    --color-primario-oscuro: #02145c;
+    --color-primario-light: #8b90ff;
+    --color-secundario: #fd778b;
+    --color-secundario-oscuro: #e46677;
+    --color-secundario-light: #ffb3c1;
     --color-gris: #6c757d;
     --color-gris-oscuro: #5a6268;
+    --color-gris-soft: #f4f6fb;
     --color-exito: #50c878;
     --color-exito-oscuro: #3ea060;
     --color-peligro: #e63946;
     --color-peligro-oscuro: #c2212d;
-    --color-claro: #f8faff;
-    --color-borde: #e1e5e9;
-    --color-info-bg: #dbeaf4;
+    --color-claro: #d2e9ff;
+    --color-borde: #b7f1f4;
+    --color-borde-light: #d2e9ff;
+    --color-background: #fcffa8;
+    --color-surface: #ffffff;
+    --color-texto: #02145c;
+    --color-texto-secondary: #5a6268;
+    --color-texto-inverse: #ffffff;
+    --color-info-bg: #b7f1f4;
     --color-exito-bg: #e6f4ea;
     --color-exito-text: #1f6135;
     --color-exito-border: #b8dfc1;
     --color-peligro-bg: #fbeaea;
     --color-peligro-text: #7b1f24;
     --color-peligro-border: #f2b6bc;
-    --color-warning-bg: #fff3cd;
-    --color-warning-border: #ffeaa7;
-    --color-info-text: #0b4b56;
-    --color-info-border: #b0d8e3;
-    --color-primario-rgb: 88, 101, 242;
+    --color-warning-bg: #fcffa8;
+    --color-warning-border: #e0e284;
+    --color-info-text: #02145c;
+    --color-info-border: #8fd0d7;
+    --color-primario-rgb: 85, 91, 246;
+    --body-gradient: linear-gradient(180deg, #fcffa8 0%, #d2e9ff 60%, #b7f1f4 100%);
+    --shadow-primary: 0 4px 20px rgba(85, 91, 246, 0.25);
+    --shadow-secondary: 0 4px 20px rgba(253, 119, 139, 0.25);
+    --shadow-soft: 0 2px 8px rgba(0, 0, 0, 0.1);
+    --shadow-medium: 0 4px 16px rgba(0, 0, 0, 0.2);
+    --shadow-strong: 0 8px 32px rgba(0, 0, 0, 0.3);
+
+    --color-primario-soft: #eef0ff;
+
     --vh: 1vh;
 }
 
@@ -39,11 +58,13 @@ html, body {
 body {
     font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 16px;
-    line-height: 1.5;
-    color: #333;
-    background-color: var(--color-claro);
+    font-weight: 400;
+    line-height: 1.6;
+    color: var(--color-texto);
+    background: var(--body-gradient, var(--color-background));
     overflow-x: hidden;
     padding-bottom: calc(80px + env(safe-area-inset-bottom));
+    transition: all 0.3s ease;
 }
 
 .visually-hidden {
@@ -64,20 +85,23 @@ body {
     padding: 20px;
 }
 
+
 .header {
     position: relative;
     display: flex;
     align-items: center;
-    justify-content: flex-end;
+    justify-content: space-between;
     gap: 20px;
-    margin: 0 0 20px;
-    padding: 10px;
-    padding-top: calc(10px + env(safe-area-inset-top));
+    margin: 0 0 24px;
+    padding: 20px;
+    padding-top: calc(20px + env(safe-area-inset-top));
     min-height: 100px;
-    background: #FF0000;
+    background: linear-gradient(90deg, var(--color-primario) 60%, var(--color-secundario)),
+                url('./IMG_1568.jpg') center/cover no-repeat;
+
     color: white;
-    border-radius: 0 0 12px 12px;
-    box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+    border-radius: 0 0 16px 16px;
+    box-shadow: var(--shadow-medium);
 }
 
 @media (max-width: 600px) {
@@ -93,6 +117,24 @@ body {
     gap: 10px;
     position: relative;
     z-index: 1;
+}
+
+.header-brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--color-texto-inverse);
+}
+
+.header-brand::before {
+    content: '💰';
+    font-size: 24px;
+}
+
+.brand-accent {
+    color: var(--color-secundario);
 }
 
 .main-content {

--- a/styles.css
+++ b/styles.css
@@ -7,16 +7,25 @@
 :root {
     --color-primario: #555bf6;
     --color-primario-oscuro: #02145c;
+    --color-primario-light: #8b90ff;
     --color-secundario: #fd778b;
     --color-secundario-oscuro: #e46677;
+    --color-secundario-light: #ffb3c1;
     --color-gris: #6c757d;
     --color-gris-oscuro: #5a6268;
+    --color-gris-soft: #f4f6fb;
     --color-exito: #50c878;
     --color-exito-oscuro: #3ea060;
     --color-peligro: #e63946;
     --color-peligro-oscuro: #c2212d;
     --color-claro: #d2e9ff;
     --color-borde: #b7f1f4;
+    --color-borde-light: #d2e9ff;
+    --color-background: #fcffa8;
+    --color-surface: #ffffff;
+    --color-texto: #02145c;
+    --color-texto-secondary: #5a6268;
+    --color-texto-inverse: #ffffff;
     --color-info-bg: #b7f1f4;
     --color-exito-bg: #e6f4ea;
     --color-exito-text: #1f6135;
@@ -29,6 +38,14 @@
     --color-info-text: #02145c;
     --color-info-border: #8fd0d7;
     --color-primario-rgb: 85, 91, 246;
+    --body-gradient: linear-gradient(180deg, #fcffa8 0%, #d2e9ff 60%, #b7f1f4 100%);
+    --shadow-primary: 0 4px 20px rgba(85, 91, 246, 0.25);
+    --shadow-secondary: 0 4px 20px rgba(253, 119, 139, 0.25);
+    --shadow-soft: 0 2px 8px rgba(0, 0, 0, 0.1);
+    --shadow-medium: 0 4px 16px rgba(0, 0, 0, 0.2);
+    --shadow-strong: 0 8px 32px rgba(0, 0, 0, 0.3);
+
+    --color-primario-soft: #eef0ff;
 
     --vh: 1vh;
 }
@@ -111,7 +128,7 @@ body {
     font-weight: 400;
     line-height: 1.6;
     color: var(--color-texto);
-    background: var(--color-background);
+    background: var(--body-gradient, var(--color-background));
     overflow-x: hidden;
     padding-bottom: calc(80px + env(safe-area-inset-bottom));
     transition: all 0.3s ease;
@@ -175,6 +192,10 @@ a:hover {
 .header-brand::before {
     content: '💰';
     font-size: 24px;
+}
+
+.brand-accent {
+    color: var(--color-secundario);
 }
 
 @media (max-width: 600px) {
@@ -277,7 +298,7 @@ a:hover {
 }
 
 .panel h2 {
-    color: #555BF6;
+    color: var(--color-primario);
     margin-bottom: 24px;
     font-size: 1.75em;
     font-weight: 700;
@@ -292,7 +313,7 @@ a:hover {
     left: 0;
     width: 60px;
     height: 3px;
-    background: #555BF6;
+    background: var(--color-primario);
     border-radius: 2px;
 }
 
@@ -330,8 +351,8 @@ select {
 
 input:focus, select:focus, textarea:focus {
     outline: none;
-    border-color: #555BF6;
-    box-shadow: 0 0 0 3px rgba(85, 91, 246, 0.1);
+    border-color: var(--color-primario);
+    box-shadow: 0 0 0 3px rgba(var(--color-primario-rgb), 0.1);
     transform: translateY(-1px);
 }
 
@@ -398,13 +419,13 @@ input[type="date"]:valid::-webkit-datetime-edit {
 }
 
 .btn-primary {
-    background: #555BF6;
-    color: white;
+    background: var(--color-primario);
+    color: var(--color-texto-inverse);
     box-shadow: var(--shadow-soft);
 }
 
 .btn-primary:hover {
-    background: #4248E8;
+    background: var(--color-primario-oscuro);
     box-shadow: var(--shadow-medium);
     transform: translateY(-2px);
 }
@@ -425,7 +446,7 @@ input[type="date"]:valid::-webkit-datetime-edit {
 }
 
 .btn-success:hover {
-    background: var(--color-exito-dark);
+    background: var(--color-exito-oscuro);
 }
 
 .btn-danger {
@@ -434,7 +455,7 @@ input[type="date"]:valid::-webkit-datetime-edit {
 }
 
 .btn-danger:hover {
-    background: var(--color-peligro-dark);
+    background: var(--color-peligro-oscuro);
 }
 
 .btn-outline {
@@ -687,8 +708,8 @@ th, td {
 }
 
 th {
-    background: #555BF6;
-    color: white;
+    background: var(--color-primario);
+    color: var(--color-texto-inverse);
     font-weight: 600;
     font-size: 14px;
     position: sticky;
@@ -752,17 +773,17 @@ tbody tr:hover {
 }
 
 .chip:hover {
-    border-color: #FD778B;
-    background: #FD778B;
-    color: white;
+    border-color: var(--color-secundario);
+    background: var(--color-secundario);
+    color: var(--color-texto-inverse);
     transform: translateY(-2px);
     box-shadow: var(--shadow-medium);
 }
 
 .chip.active {
-    background: #555BF6;
-    border-color: #555BF6;
-    color: white;
+    background: var(--color-primario);
+    border-color: var(--color-primario);
+    color: var(--color-texto-inverse);
     box-shadow: var(--shadow-soft);
     transform: translateY(-2px);
 }


### PR DESCRIPTION
## Summary
- define brand color variables and gradient backgrounds
- highlight header and components with primary and secondary accents
- update buttons, tables and chips to follow new palette
- apply palette in public header and theme color for consistent branding

## Testing
- `npm test` *(fails: draft persistence and app suites)*

------
https://chatgpt.com/codex/tasks/task_e_68af76e11b4883298d8fb4141444931b