### PR TITLE
feat: redesign UI with brandbook components

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-background text-text font-sans;
+}
+
+:focus-visible {
+  outline: 2px solid theme('colors.brand-blue');
+  outline-offset: 2px;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,13 @@
+import './globals.css'
+import { Work_Sans } from 'next/font/google'
+import { ReactNode } from 'react'
+
+const workSans = Work_Sans({ subsets: ['latin'], weight: ['400', '500', '600'], variable: '--font-sans' })
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="es" className={workSans.variable}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,52 @@
+import { Button } from '../components/ui/button'
+import { Card } from '../components/ui/card'
+import { EmptyState } from '../components/ui/empty-state'
+import { Table, THead, TBody, TR, TH, TD } from '../components/ui/table'
+
+export default function Page() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <nav className="w-full bg-navbar px-6 py-4 flex items-center justify-between">
+        <div className="text-text font-semibold text-xl">Exora</div>
+        <Button variant="gradient">Cambiar sucursal</Button>
+      </nav>
+      <main className="flex-1 container mx-auto p-6 space-y-6">
+        <div className="grid md:grid-cols-2 gap-6">
+          <Card>
+            <h2 className="text-2xl font-semibold text-brand-blue mb-4">Registro del Día</h2>
+            <EmptyState title="Completa el formulario para registrar" />
+          </Card>
+          <Card>
+            <h2 className="text-2xl font-semibold text-brand-blue mb-4">Historial</h2>
+            <Table>
+              <THead>
+                <TR>
+                  <TH>Fecha</TH>
+                  <TH>Ingresos</TH>
+                  <TH>Cierre</TH>
+                </TR>
+              </THead>
+              <TBody>
+                <TR>
+                  <TD>01/01/2024</TD>
+                  <TD className="text-right">100€</TD>
+                  <TD className="text-right">90€</TD>
+                </TR>
+                <TR>
+                  <TD>02/01/2024</TD>
+                  <TD className="text-right">120€</TD>
+                  <TD className="text-right">110€</TD>
+                </TR>
+              </TBody>
+            </Table>
+          </Card>
+        </div>
+        <div className="flex gap-4">
+          <Button variant="primary">Guardar</Button>
+          <Button variant="pink">Nuevo</Button>
+          <Button variant="destructive">Borrar</Button>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'pink' | 'destructive' | 'gradient'
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'rounded-[16px] px-6 py-3 font-medium text-text transition-transform duration-150 ease-out shadow-sm',
+          'hover:shadow-hover hover:-translate-y-[2px]',
+          {
+            primary: 'bg-brand-blue',
+            pink: 'bg-brand-pink',
+            gradient: 'bg-gradient-to-r from-brand-blue to-brand-pink',
+            destructive: 'bg-[#E74C3C] text-white hover:bg-[#c0392b]'
+          }[variant],
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = 'Button'

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Card({ className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'bg-card rounded-[16px] p-6 shadow-card animate-card-in',
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
+  icon?: React.ReactNode
+  title?: string
+}
+
+export function EmptyState({ icon, title, className, ...props }: EmptyStateProps) {
+  return (
+    <div
+      className={cn('flex flex-col items-center justify-center text-center gap-2 text-text', className)}
+      {...props}
+    >
+      {icon || (
+        <svg
+          className="h-10 w-10 text-gray-500"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 13h6m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h8l6 6v10a2 2 0 01-2 2z" />
+        </svg>
+      )}
+      {title && <p className="text-base">{title}</p>}
+    </div>
+  )
+}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> {}
+
+export function Table({ className, ...props }: TableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table
+        className={cn('w-full border-separate border-spacing-0 text-sm', className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+export function THead({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return (
+    <thead className={cn('bg-brand-blue text-text font-semibold', className)} {...props} />
+  )
+}
+
+export function TBody({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={cn('', className)} {...props} />
+}
+
+export function TR({ className, ...props }: React.HTMLAttributes<HTMLTableRowElement>) {
+  return (
+    <tr
+      className={cn('odd:bg-card even:bg-background hover:bg-[#1a2142] border-b border-border', className)}
+      {...props}
+    />
+  )
+}
+
+export function TH({ className, ...props }: React.ThHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      className={cn('px-4 py-2 text-left first:rounded-tl-[16px] last:rounded-tr-[16px]', className)}
+      {...props}
+    />
+  )
+}
+
+export function TD({ className, ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn('px-4 py-2', className)} {...props} />
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "dev": "python3 -m http.server 8000",
-    "start": "node server.js",
+    "dev": "next dev",
+    "start": "next start",
     "test:watch": "npm test -- --watch",
-    "build": "node scripts/build.js",
+    "build": "next build",
     "build:public": "mkdir -p public && cp -r *.html *.js *.css *.json *.png modules utils api config public/ 2>/dev/null || true",
     "serve": "python3 -m http.server 8000",
     "deploy:vercel": "vercel",
@@ -22,12 +22,22 @@
   "dependencies": {
     "pg": "^8.11.3",
     "nodemailer": "^6.9.4",
-    "googleapis": "^139.0.0"
+    "googleapis": "^139.0.0",
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "tailwind-merge": "^2.3.0"
   },
   "keywords": ["pwa", "cash-management", "google-sheets", "barbershop"],
   "author": "LBJ Team",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,39 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ['class'],
+  content: [
+    './pages/**/*.{ts,tsx,js,jsx}',
+    './components/**/*.{ts,tsx,js,jsx}',
+    './app/**/*.{ts,tsx,js,jsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0B1020',
+        card: '#121830',
+        navbar: '#02145C',
+        'brand-blue': '#555BF6',
+        'brand-pink': '#FD778B',
+        text: '#E6E9F2',
+        border: '#02145C',
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)'],
+      },
+      boxShadow: {
+        card: '0 2px 4px rgba(0,0,0,0.1)',
+        hover: '0 4px 8px rgba(0,0,0,0.2)',
+      },
+      keyframes: {
+        'fade-in': {
+          from: { opacity: 0, transform: 'translateY(12px)' },
+          to: { opacity: 1, transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'card-in': 'fade-in 0.2s ease-out',
+      },
+    },
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "noEmit": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Next.js with Tailwind and Work Sans font
- add reusable UI components (Button, Card, Table, EmptyState)
- apply Exora brand palette and animations

## Testing
- `npm test` *(fails: draft.test.js, app.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68af80609f548329805c2ee58987f177