### PR TITLE
Fix daily log calculation error

### DIFF
--- a/app.js
+++ b/app.js
@@ -1042,6 +1042,9 @@ document.addEventListener('DOMContentLoaded', function() {
     // Event listeners para recálculo automático
     ['apertura', 'ingresos', 'ingresosTarjetaExora', 'ingresosTarjetaDatafono', 'cierre'].forEach(id => {
         const element = document.getElementById(id);
+        if (!element) {
+            return;
+        }
         element.addEventListener('input', recalc);
         element.addEventListener('blur', function() {
             this.value = formatCurrency(this.value);
@@ -1055,6 +1058,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     ['responsableApertura', 'responsableCierre'].forEach(id => {
         const element = document.getElementById(id);
+        if (!element) {
+            return;
+        }
         element.addEventListener('input', saveDraft);
     });
     


### PR DESCRIPTION
Add element existence checks before attaching event listeners to prevent JavaScript errors that could stop calculation updates for the "registro del dia" green cells.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea9532c0-6425-4b89-ac1b-7861e26c856d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea9532c0-6425-4b89-ac1b-7861e26c856d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

