### PR TITLE
Fix treasury movements retrieval on editing

### DIFF
--- a/api/googleSheets.js
+++ b/api/googleSheets.js
@@ -159,7 +159,7 @@ export async function updateRecord(id, data) {
 
 export function buildTesoreriaRow(id, fecha, mov) {
   return [
-    id,
+    String(id),
     fecha || '',
     mov.tipo === 'entrada' ? 'Entrada' : 'Salida',
     mov.quien || '',
@@ -177,8 +177,12 @@ export async function deleteTesoreriaMovimientos(cierreId) {
   const rows = res.data.values || [];
   const rowsToDelete = [];
   rows.forEach((r, idx) => {
-    if ((r[0] || '').startsWith(`${cierreId}-`)) {
+    const cell = r[0] ? String(r[0]) : '';
+    if (cell.startsWith(`${cierreId}-`)) {
       rowsToDelete.push(idx + 1);
+    } else if (/^\d+$/.test(String(cierreId)) && /^\d+$/.test(cell)) {
+      const diff = Number(cierreId) - Number(cell);
+      if (diff >= 0 && diff < 100) rowsToDelete.push(idx + 1);
     }
   });
 
@@ -239,7 +243,7 @@ export async function appendTesoreriaMovimientos(
     await client.spreadsheets.values.update({
       spreadsheetId: SHEET_ID,
       range: `${TESORERIA_SHEET_NAME}!A2:E${1 + values.length}`,
-      valueInputOption: 'USER_ENTERED',
+      valueInputOption: 'RAW',
       requestBody: { values },
     });
   }

--- a/api/list-tesoreria.js
+++ b/api/list-tesoreria.js
@@ -40,7 +40,16 @@ export default async function handler(req, res) {
     const rows = response.data.values || [];
 
     const movimientos = rows
-      .filter(r => r[0] && String(r[0]).startsWith(`${id}-`))
+      .filter(r => {
+        if (!r[0]) return false;
+        const cell = String(r[0]);
+        if (cell.startsWith(`${id}-`)) return true;
+        if (/^\d+$/.test(id) && /^\d+$/.test(cell)) {
+          const diff = Number(id) - Number(cell);
+          if (diff >= 0 && diff < 100) return true;
+        }
+        return false;
+      })
       .map(r => ({
         tipo: (r[2] || '').toString().toLowerCase() === 'entrada' ? 'entrada' : 'salida',
         quien: r[3] || '',

--- a/app.js
+++ b/app.js
@@ -398,7 +398,7 @@ function loadFormData(data) {
     ['apertura', 'ingresos', 'ingresosTarjetaExora', 'ingresosTarjetaDatafono', 'cierre'].forEach(id => {
         const element = document.getElementById(id);
         const value = parseFloat(element.value);
-        if (!isNaN(value) && value > 0) {
+        if (!isNaN(value) && value > 0 && typeof updateCurrencyDisplay === 'function') {
             updateCurrencyDisplay(element, value);
         }
     });


### PR DESCRIPTION
## Summary
- ensure treasury movement IDs are saved as raw text in Sheets and clean up previous mis-saved rows
- support reading legacy numeric IDs when listing treasury movements
- guard currency display updates in forms when running without UI helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8ab2cda608329bb16b36f24abfcd8